### PR TITLE
fix(server): add missing vector field to RpcQuery in federated_search

### DIFF
--- a/prism-server/src/main.rs
+++ b/prism-server/src/main.rs
@@ -572,6 +572,7 @@ fn cluster_routes(
 
         let rpc_query = prism_cluster::RpcQuery {
             query_string,
+            vector: None,
             fields: vec![],
             limit,
             offset: 0,


### PR DESCRIPTION
## Problem
Building `prismsearch-server` with `--features cluster` fails to compile:

```
error[E0063]: missing field `vector` in initializer of `RpcQuery`
   --> prism-server/src/main.rs:573
```

The `federated_search` handler (gated behind `#[cfg(feature = "cluster")]`) initializes `prism_cluster::RpcQuery` without the `vector` field. Because this code only compiles under the `cluster` feature, the error was **latent** — non-cluster builds never hit it.

Discovered while building a full-feature (`cluster` + `es-compat` + …) release for prod.

## Fix
Set `vector: None` — this federated route does text-only search.

## Verification
Full-feature `prismsearch-server` release build now compiles and runs (deployed as 0.6.11, es-compat live).