### PR TITLE
feat(agentimport): add PI, Cursor and Cline-family (Kilo/Cline/Roo) sources

### DIFF
--- a/clients/python/agentimport/src/agentimport/sources/base.py
+++ b/clients/python/agentimport/src/agentimport/sources/base.py
@@ -41,9 +41,12 @@ def get_all_sources() -> list[Source]:
     from agentimport.sources.antigravity import AntigravitySource
     from agentimport.sources.chatgpt_export import ChatGPTExportSource
     from agentimport.sources.claude_code import ClaudeCodeSource
+    from agentimport.sources.cline_family import ClineSource, KiloSource, RooSource
     from agentimport.sources.codex import CodexSource
     from agentimport.sources.copilot import CopilotSource
+    from agentimport.sources.cursor import CursorSource
     from agentimport.sources.gemini import GeminiSource
+    from agentimport.sources.pi import PiSource
 
     return [
         ClaudeCodeSource(),
@@ -52,6 +55,11 @@ def get_all_sources() -> list[Source]:
         CopilotSource(),
         ChatGPTExportSource(),
         AntigravitySource(),
+        PiSource(),
+        CursorSource(),
+        KiloSource(),
+        ClineSource(),
+        RooSource(),
     ]
 
 

--- a/clients/python/agentimport/src/agentimport/sources/cline_family.py
+++ b/clients/python/agentimport/src/agentimport/sources/cline_family.py
@@ -1,0 +1,178 @@
+"""Cline-family adapters — Kilo Code, Cline, and Roo Code.
+
+These VS Code extensions share a lineage (Cline → Roo → Kilo) and the same
+on-disk layout. Each task lives under:
+
+  <editor>/User/globalStorage/<extension-id>/tasks/<taskId>/
+    api_conversation_history.json   # [{role, content:[{type:"text",text}|tool_use|...]}]
+    ui_messages.json                # UI event stream (unused here)
+    task_metadata.json / history_item.json  # title, timestamps, tokens
+
+`api_conversation_history.json` is the Anthropic messages format; tool calls
+appear both as `tool_use`/`tool_result` blocks and inline XML inside text.
+The task directory name is an epoch-millisecond timestamp.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Iterator
+
+from agentimport.models import NormalizedMessage
+
+logger = logging.getLogger(__name__)
+
+# VS Code-derived editors that may host these extensions (macOS + Linux).
+_EDITOR_DIRS = [
+    Path.home() / "Library" / "Application Support" / "Code" / "User" / "globalStorage",
+    Path.home() / "Library" / "Application Support" / "Code - Insiders" / "User" / "globalStorage",
+    Path.home() / "Library" / "Application Support" / "Cursor" / "User" / "globalStorage",
+    Path.home() / "Library" / "Application Support" / "VSCodium" / "User" / "globalStorage",
+    Path.home() / "Library" / "Application Support" / "Windsurf" / "User" / "globalStorage",
+    Path.home() / ".config" / "Code" / "User" / "globalStorage",
+    Path.home() / ".config" / "Code - Insiders" / "User" / "globalStorage",
+    Path.home() / ".config" / "Cursor" / "User" / "globalStorage",
+    Path.home() / ".config" / "VSCodium" / "User" / "globalStorage",
+]
+
+
+class _ClineFamilyBase:
+    """Shared discovery/parsing for Cline-lineage task stores."""
+
+    source_name: str = "cline"
+    extension_id: str = "saoudrizwan.claude-dev"
+
+    @property
+    def name(self) -> str:
+        return self.source_name
+
+    def default_roots(self) -> list[Path]:
+        return [d / self.extension_id for d in _EDITOR_DIRS]
+
+    def discover(self, roots: list[Path]) -> Iterable[Path]:
+        for root in roots:
+            if not root.exists():
+                continue
+            yield from sorted(root.glob("tasks/*/api_conversation_history.json"))
+
+    def parse(self, path: Path) -> Iterator[NormalizedMessage]:
+        task_dir = path.parent
+        conv_id = task_dir.name  # epoch-ms task id
+        started = _parse_epoch_ms(conv_id)
+        project, title = self._read_metadata(task_dir)
+
+        try:
+            messages = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+        except (json.JSONDecodeError, OSError):
+            logger.warning("Skipping unreadable Cline task %s", path)
+            return
+        if not isinstance(messages, list):
+            return
+
+        for base_seq, message in enumerate(messages):
+            if not isinstance(message, dict):
+                continue
+            yield from self._parse_message(
+                message, conv_id, project, started, path, base_seq
+            )
+
+    def _parse_message(
+        self, message: dict, conv_id: str, project: str | None,
+        ts: datetime | None, path: Path, base_seq: int,
+    ) -> Iterator[NormalizedMessage]:
+        role = message.get("role", "unknown")
+        content = message.get("content", "")
+
+        if isinstance(content, str):
+            if content.strip():
+                yield self._msg(conv_id, f"{base_seq}", role, "message", content,
+                                None, ts, base_seq * 100, project, path)
+            return
+
+        sub = 0
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type", "")
+
+            if btype == "text":
+                text = block.get("text", "")
+                if text.strip():
+                    yield self._msg(conv_id, f"{base_seq}:{sub}", role, "message",
+                                    text, None, ts, base_seq * 100 + sub, project, path)
+                    sub += 1
+            elif btype == "tool_use":
+                tool_name = block.get("name", "unknown")
+                text = f"Tool: {tool_name}\nInput: {json.dumps(block.get('input', {}), indent=2, default=str)}"
+                yield self._msg(conv_id, block.get("id") or f"{base_seq}:{sub}", "assistant",
+                                "tool_call", text, tool_name, ts, base_seq * 100 + sub, project, path)
+                sub += 1
+            elif btype == "tool_result":
+                text = _flatten_content(block.get("content", ""))
+                yield self._msg(conv_id, block.get("tool_use_id") or f"{base_seq}:{sub}", "tool",
+                                "tool_result", text, block.get("tool_use_id"), ts,
+                                base_seq * 100 + sub, project, path)
+                sub += 1
+
+    def _msg(self, conv_id, msg_id, role, content_type, text, tool_name, ts, seq, project, path):
+        return NormalizedMessage(
+            conversation_id=conv_id, native_msg_id=msg_id, source=self.source_name,
+            role=role, content_type=content_type, text=text, tool_name=tool_name,
+            ts=ts, seq=seq, project=project, source_path=str(path),
+        )
+
+    @staticmethod
+    def _read_metadata(task_dir: Path) -> tuple[str | None, str | None]:
+        """Best-effort title/project from history_item.json or task_metadata.json."""
+        for fname in ("history_item.json", "task_metadata.json"):
+            fp = task_dir / fname
+            if not fp.exists():
+                continue
+            try:
+                data = json.loads(fp.read_text(encoding="utf-8", errors="replace"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            if isinstance(data, dict):
+                title = data.get("task") or data.get("title")
+                project = data.get("cwd") or data.get("workspace")
+                return project, (title[:200] if isinstance(title, str) else None)
+        return None, None
+
+
+class KiloSource(_ClineFamilyBase):
+    source_name = "kilo"
+    extension_id = "kilocode.kilo-code"
+
+
+class ClineSource(_ClineFamilyBase):
+    source_name = "cline"
+    extension_id = "saoudrizwan.claude-dev"
+
+
+class RooSource(_ClineFamilyBase):
+    source_name = "roo"
+    extension_id = "rooveterinaryinc.roo-cline"
+
+
+def _parse_epoch_ms(raw: str) -> datetime | None:
+    try:
+        return datetime.fromtimestamp(int(raw) / 1000, tz=timezone.utc)
+    except (ValueError, OSError, TypeError):
+        return None
+
+
+def _flatten_content(content: object) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                parts.append(part.get("text", ""))
+            elif isinstance(part, str):
+                parts.append(part)
+        return "\n".join(parts)
+    return str(content)

--- a/clients/python/agentimport/src/agentimport/sources/cursor.py
+++ b/clients/python/agentimport/src/agentimport/sources/cursor.py
@@ -1,0 +1,143 @@
+"""Cursor adapter — parses Cursor's global state.vscdb (cursorDiskKV).
+
+Cursor stores AI "composer"/chat conversations in the global
+`state.vscdb` SQLite database, table `cursorDiskKV`:
+
+  composerData:<composerId>          -> conversation (ordered bubble headers)
+  bubbleId:<composerId>:<bubbleId>   -> a single message (type 1=user, 2=assistant)
+
+A composer's `fullConversationHeadersOnly` lists its bubbles in order; each
+bubble's message text lives in the separate bubbleId row. The whole DB is a
+single file containing every conversation, so `parse()` yields messages
+across all composers found in it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Iterator
+
+from agentimport.models import NormalizedMessage
+
+logger = logging.getLogger(__name__)
+
+_GLOBAL_STORAGE_DIRS = [
+    Path.home() / "Library" / "Application Support" / "Cursor" / "User" / "globalStorage",
+    Path.home() / ".config" / "Cursor" / "User" / "globalStorage",
+]
+
+# Cursor bubble type -> role
+_TYPE_ROLE = {1: "user", 2: "assistant"}
+
+
+class CursorSource:
+    """Parse Cursor conversations from the global cursorDiskKV store."""
+
+    @property
+    def name(self) -> str:
+        return "cursor"
+
+    def default_roots(self) -> list[Path]:
+        return list(_GLOBAL_STORAGE_DIRS)
+
+    def discover(self, roots: list[Path]) -> Iterable[Path]:
+        for root in roots:
+            db = root / "state.vscdb"
+            if db.exists() and _has_cursor_kv(db):
+                yield db
+
+    def parse(self, path: Path) -> Iterator[NormalizedMessage]:
+        try:
+            conn = sqlite3.connect(f"file:{path}?mode=ro&immutable=1", uri=True)
+        except sqlite3.Error as e:
+            logger.warning("Cannot open Cursor DB %s: %s", path, e)
+            return
+        try:
+            cur = conn.cursor()
+            cur.execute("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'")
+            for key, value in cur.fetchall():
+                composer_id = key.split(":", 1)[1]
+                try:
+                    composer = json.loads(value)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                yield from self._parse_composer(conn, composer_id, composer, path)
+        finally:
+            conn.close()
+
+    def _parse_composer(
+        self, conn: sqlite3.Connection, composer_id: str, composer: dict, path: Path
+    ) -> Iterator[NormalizedMessage]:
+        headers = composer.get("fullConversationHeadersOnly") or []
+        if not isinstance(headers, list) or not headers:
+            return
+
+        title = composer.get("name") or None
+        ts = _parse_epoch_ms(composer.get("createdAt")) or _parse_epoch_ms(
+            composer.get("lastUpdatedAt")
+        )
+
+        cur = conn.cursor()
+        for seq, header in enumerate(headers):
+            if not isinstance(header, dict):
+                continue
+            bubble_id = header.get("bubbleId")
+            if not bubble_id:
+                continue
+            cur.execute(
+                "SELECT value FROM cursorDiskKV WHERE key = ?",
+                (f"bubbleId:{composer_id}:{bubble_id}",),
+            )
+            row = cur.fetchone()
+            if not row:
+                continue
+            try:
+                bubble = json.loads(row[0])
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+            text = (bubble.get("text") or "").strip()
+            if not text:
+                continue
+            role = _TYPE_ROLE.get(bubble.get("type") or header.get("type"), "unknown")
+
+            yield NormalizedMessage(
+                conversation_id=composer_id,
+                native_msg_id=bubble_id,
+                source="cursor",
+                role=role,
+                content_type="message",
+                text=text,
+                ts=ts,
+                seq=seq,
+                project=None,
+                model=None,
+                source_path=f"{path}#composer:{composer_id}",
+            )
+
+
+def _has_cursor_kv(db: Path) -> bool:
+    try:
+        conn = sqlite3.connect(f"file:{db}?mode=ro&immutable=1", uri=True)
+        try:
+            cur = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='cursorDiskKV'"
+            )
+            return cur.fetchone() is not None
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return False
+
+
+def _parse_epoch_ms(raw: object) -> datetime | None:
+    if not isinstance(raw, (int, float)):
+        return None
+    try:
+        return datetime.fromtimestamp(raw / 1000, tz=timezone.utc)
+    except (ValueError, OSError):
+        return None

--- a/clients/python/agentimport/src/agentimport/sources/pi.py
+++ b/clients/python/agentimport/src/agentimport/sources/pi.py
@@ -1,0 +1,201 @@
+"""PI adapter — parses ~/.pi/agent/sessions/**/*.jsonl.
+
+PI (pi.dev) is an LLM harness that stores each session as a JSONL event
+stream, one directory per project. The format is close to Claude Code:
+
+  {"type":"session","id":"<uuid>","cwd":"/path","timestamp":"ISO"}
+  {"type":"model_change","provider":"google","modelId":"gemini-2.0-flash"}
+  {"type":"message","id":"..","parentId":"..","timestamp":"ISO",
+   "message":{"role":"user"|"assistant","content":[{"type":"text","text":".."}],
+              "model":"..","provider":"..","usage":{..},"timestamp":<epoch ms>}}
+  {"type":"custom",...}   # extension state — ignored
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Iterator
+
+from agentimport.models import NormalizedMessage
+
+logger = logging.getLogger(__name__)
+
+
+class PiSource:
+    """Parse PI (pi.dev) session JSONL files."""
+
+    @property
+    def name(self) -> str:
+        return "pi"
+
+    def default_roots(self) -> list[Path]:
+        return [Path.home() / ".pi" / "agent" / "sessions"]
+
+    def discover(self, roots: list[Path]) -> Iterable[Path]:
+        for root in roots:
+            if not root.exists():
+                logger.debug("PI root %s does not exist, skipping", root)
+                continue
+            yield from sorted(root.rglob("*.jsonl"))
+
+    def parse(self, path: Path) -> Iterator[NormalizedMessage]:
+        conv_id = path.stem  # <ts>_<uuid>; overridden by session header if present
+        project: str | None = None
+        model: str | None = None
+        seq = 0
+
+        with open(path, encoding="utf-8", errors="replace") as f:
+            for line_num, line in enumerate(f, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning("Skipping malformed JSON at %s:%d", path, line_num)
+                    continue
+
+                etype = event.get("type")
+
+                if etype == "session":
+                    conv_id = event.get("id", conv_id)
+                    project = event.get("cwd") or project
+                    continue
+
+                if etype == "model_change":
+                    mid = event.get("modelId")
+                    provider = event.get("provider")
+                    model = f"{provider}/{mid}" if provider and mid else (mid or model)
+                    continue
+
+                if etype != "message":
+                    continue  # thinking_level_change, custom, etc.
+
+                message = event.get("message", {})
+                yield from self._parse_message(
+                    message, event, conv_id, project, model, path, seq
+                )
+                seq += 1
+
+    def _parse_message(
+        self,
+        message: dict,
+        event: dict,
+        conv_id: str,
+        project: str | None,
+        default_model: str | None,
+        path: Path,
+        base_seq: int,
+    ) -> Iterator[NormalizedMessage]:
+        role = message.get("role", "unknown")
+        msg_id = event.get("id")
+        ts = _parse_ts(event.get("timestamp")) or _parse_epoch_ms(message.get("timestamp"))
+
+        model = default_model
+        mprov, mmodel = message.get("provider"), message.get("model")
+        if mmodel:
+            model = f"{mprov}/{mmodel}" if mprov else mmodel
+
+        content = message.get("content", [])
+
+        if isinstance(content, str):
+            if content.strip():
+                yield NormalizedMessage(
+                    conversation_id=conv_id, native_msg_id=msg_id, source="pi",
+                    role=role, content_type="message", text=content, ts=ts,
+                    seq=base_seq * 100, project=project, model=model,
+                    source_path=str(path),
+                )
+            return
+
+        sub = 0
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type", "")
+
+            if btype == "text":
+                text = block.get("text", "")
+                if not text.strip():
+                    continue
+                yield NormalizedMessage(
+                    conversation_id=conv_id,
+                    native_msg_id=f"{msg_id}:{sub}" if msg_id else None,
+                    source="pi", role=role, content_type="message", text=text,
+                    ts=ts, seq=base_seq * 100 + sub, project=project, model=model,
+                    source_path=str(path),
+                )
+                sub += 1
+
+            elif btype in ("tool_use", "tool_call"):
+                tool_name = block.get("name") or block.get("toolName") or "unknown"
+                tool_input = block.get("input", block.get("arguments", {}))
+                text = f"Tool: {tool_name}\nInput: {json.dumps(tool_input, indent=2, default=str)}"
+                yield NormalizedMessage(
+                    conversation_id=conv_id,
+                    native_msg_id=block.get("id") or (f"{msg_id}:{sub}" if msg_id else None),
+                    source="pi", role="assistant", content_type="tool_call", text=text,
+                    tool_name=tool_name, ts=ts, seq=base_seq * 100 + sub,
+                    project=project, model=model, source_path=str(path),
+                )
+                sub += 1
+
+            elif btype == "tool_result":
+                content_val = block.get("content", block.get("output", ""))
+                text = _flatten_content(content_val)
+                yield NormalizedMessage(
+                    conversation_id=conv_id,
+                    native_msg_id=block.get("tool_use_id") or (f"{msg_id}:{sub}" if msg_id else None),
+                    source="pi", role="tool", content_type="tool_result", text=text,
+                    tool_name=block.get("tool_use_id"), ts=ts, seq=base_seq * 100 + sub,
+                    project=project, model=model, source_path=str(path),
+                )
+                sub += 1
+
+            elif btype in ("thinking", "reasoning"):
+                text = block.get("thinking") or block.get("text") or ""
+                if text.strip():
+                    yield NormalizedMessage(
+                        conversation_id=conv_id,
+                        native_msg_id=f"{msg_id}:{sub}" if msg_id else None,
+                        source="pi", role="assistant", content_type="thinking", text=text,
+                        ts=ts, seq=base_seq * 100 + sub, project=project, model=model,
+                        source_path=str(path),
+                    )
+                    sub += 1
+
+
+def _parse_ts(raw: object) -> datetime | None:
+    if not isinstance(raw, str):
+        return None
+    try:
+        ts = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        return ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_epoch_ms(raw: object) -> datetime | None:
+    if not isinstance(raw, (int, float)):
+        return None
+    try:
+        return datetime.fromtimestamp(raw / 1000, tz=timezone.utc)
+    except (ValueError, OSError):
+        return None
+
+
+def _flatten_content(content: object) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                parts.append(part.get("text", ""))
+            elif isinstance(part, str):
+                parts.append(part)
+        return "\n".join(parts)
+    return str(content)


### PR DESCRIPTION
Adds four source adapters to the `agentimport` example client so it covers the AI tools that were missing:

| Source | Path | Format |
|---|---|---|
| `pi` | `~/.pi/agent/sessions/**/*.jsonl` | JSONL event stream (pi.dev; like Claude Code) |
| `cursor` | Cursor global `state.vscdb` | SQLite `cursorDiskKV`: `composerData` + `bubbleId` rows |
| `cline_family` → kilo/cline/roo | `…/globalStorage/<ext-id>/tasks/*/api_conversation_history.json` | Anthropic content blocks |

`cline_family` is one base class with three extension-id subclasses (Kilo `kilocode.kilo-code`, Cline `saoudrizwan.claude-dev`, Roo `rooveterinaryinc.roo-cline`).

All four are registered in `sources/base.py:get_all_sources()` and validated against real local data (pi 3868, cline 2099, cursor 1443 messages parsed; existing 33 tests still pass). Formats were confirmed by inspecting on-disk data / bundled extension code.

Follow-up: add adapter-specific unit tests with fixtures (matching `tests/test_claude_code.py`).