### PR TITLE
feat(security): user isolation mode — enumeration + read-route ACL + namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Prism are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Opt-in user isolation mode** (`[security] isolation`, off by default). An api
+  key's `namespace` implicitly grants read+search on `<namespace>*` (never
+  write/delete/admin) without a hand-written role, and every collection
+  enumeration/read/search surface restricts results to what the caller may see:
+  `GET /admin/collections`, per-collection `/search`, `get_document`,
+  `list_documents`, `stats`, `schema` (+ raw), `aggregate`, `_suggest`, `_mlt`,
+  and `segments`. Denied single-collection access returns `404` under isolation
+  (so names don't leak via status codes), else `403`. With security disabled the
+  behavior is unchanged. This also closes a direct-name ACL hole: per-collection
+  `/collections/:c/search` previously searched any named collection without a
+  permission check, bypassing the filtering `simple_search`/`_msearch` already do.
+
 ## [0.6.12] - 2026-08-03
 
 Ships the work that was staged as 0.6.11 but never released (its tag was never

--- a/docs/plans/2026-08-03-user-isolation-design.md
+++ b/docs/plans/2026-08-03-user-isolation-design.md
@@ -1,0 +1,137 @@
+# User Isolation Mode — Design & Plan
+
+**Date:** 2026-08-03
+**Status:** Proposal
+**Effort estimate:** Small–Medium (~1 focused day for the core; ES-compat audit is the long pole)
+
+## Goal
+
+An **opt-in** mode where an authenticated identity sees and can act on **only its
+own collections** — never enumerating, searching, or reading collections it has
+no grant for. Off by default (single-tenant behavior unchanged).
+
+Motivating convention: collections on prod are already namespaced by owner as
+`ws_<user>_<type>_<name>` (e.g. `ws_mikalv_code_...`, `ws_eyrmedical_...`), so
+per-user isolation maps naturally onto a collection-name prefix.
+
+## Current state (what already exists)
+
+The per-collection ACL model is **largely built** — this is not a from-scratch
+feature.
+
+- **Identity → roles → per-collection permissions.** `SecurityConfig` has
+  `api_keys` (`key → roles`) and `roles` (`RoleConfig.collections: HashMap<pattern,
+  Vec<permission>>`). `config/mod.rs:209-243`.
+- **`PermissionChecker`** (`security/permissions.rs`): `authenticate(api_key) →
+  AuthUser`; `check_permission(user, collection, Permission)` iterates the user's
+  roles → collection patterns → returns true on a `glob_match` + permission hit.
+  **Defaults to `false` (default-deny).**
+- **`Permission`** enum: `Read, Write, Delete, Search, Admin` (`security/types.rs`).
+- **`glob_match`** supports exact and trailing-`*` prefix patterns (`ws_mikalv_*`).
+- **Search surfaces already enforce it:**
+  - `simple_search` (`/api/search`) filters the all-collections fan-out by
+    `Search` permission and returns `403` on an explicit unauthorized collection
+    (`routes.rs:292-338`).
+  - `multi_search` (`/_msearch`) checks `Search` on every requested collection
+    (`routes.rs:1665-1667`).
+
+So isolation is **already configurable today** on the search paths: give a key a
+role with `collections: { "ws_mikalv_*": ["search", "read"] }`.
+
+## Gap analysis (what's missing)
+
+1. **`GET /admin/collections` does not filter** — `list_collections`
+   (`routes.rs:692`) returns *all* collection names to any caller. This is the
+   primary enumeration leak: the web UI dropdown, `agentimport`, and any client
+   see every collection name. **Fix: add `user_ext`/`checker_ext` and filter by
+   `check_permission(user, c, Search|Read)` — the same pattern as `simple_search`.**
+2. **Un-audited single-collection read surfaces.** Each per-collection route must
+   gate on `check_permission` (Read/Search): `/collections/:c/schema`, `/stats`,
+   `/documents/:id`, `/segments`, `/_suggest`, `/_mlt`, `/aggregate`, graph
+   endpoints. Any that skip the check leak data by direct name access.
+3. **ES-compat surface.** `/_elastic/_cat/indices`, `/_aliases`, and cross-index
+   `_search`/`_msearch` must apply the same filter — without breaking official ES
+   clients' expectations. This is the fiddliest area and the main effort/risk.
+4. **Cluster / federated search** must propagate the identity filter so a
+   federated fan-out cannot reach unauthorized shards/collections.
+5. **Ergonomics.** Writing one role per user is tedious. Add an opt-in mode plus a
+   convention that auto-derives the allowed pattern from key identity.
+
+## Design
+
+### Config
+
+```toml
+[security]
+enabled = true
+isolation = true            # NEW — opt-in; off by default
+
+[[security.api_keys]]
+key = "..."
+name = "mikalv"
+namespace = "ws_mikalv_"    # NEW — auto-grants ws_mikalv_* (search+read) under isolation
+roles = []                  # still composable with explicit roles
+```
+
+- `isolation = false` (default): behavior unchanged.
+- `isolation = true`: a key's `namespace` is compiled into an implicit
+  `search`+`read` grant on `<namespace>*` and **all enumeration/read/search
+  surfaces default-deny** anything outside the union of the key's explicit-role
+  patterns and its namespace pattern.
+
+### Single enforcement point
+
+Introduce one resolver used by **every** enumeration and fan-out path:
+
+```rust
+// returns the subset of `all` the identity may see, honoring isolation mode
+fn visible_collections(user: Option<&AuthUser>, checker: Option<&PermissionChecker>,
+                       all: Vec<String>, perm: Permission) -> Vec<String>
+```
+
+`list_collections`, `simple_search`, `multi_search`, ES-compat `_cat`/cross-index
+search, and cluster fan-out all call this — no duplicated filtering logic, no
+missed surface. Single-collection routes call `check_permission` directly and
+return `403`/`404` (prefer `404` under isolation so names don't leak via status).
+
+## Implementation plan (phased)
+
+1. **Enumeration filter (highest value, lowest risk).** Add the resolver; wire
+   `list_collections` to it. Tests: key A cannot see key B's collections.
+2. **Audit + gate single-collection read routes.** Add `check_permission` to every
+   `/collections/:c/*` read/stat route; `404` (not `403`) under isolation.
+3. **Config + auto-namespace + default-deny.** Add `isolation` flag and
+   `ApiKeyConfig.namespace`; compile the implicit grant; make listing default-deny
+   when isolation is on.
+4. **ES-compat surface.** Filter `_cat/indices`, `_aliases`, cross-index
+   `_search`/`_msearch`; keep official-client compatibility.
+5. **Cluster/federated.** Propagate the identity filter through federated search.
+6. **UI.** The collection browser/dropdown just consumes the now-filtered
+   `/admin/collections` — little or no UI change.
+
+## Risks
+
+- **ES-compat breakage** — the largest surface; external ES clients have
+  behavioral expectations for `_cat`/`_search`. Needs integration tests.
+- **Leak completeness** — any missed enumeration path (aggregations, suggest, mlt,
+  graph, stats, segments, health `collections` count) undermines isolation. The
+  single-resolver approach plus a route audit checklist mitigates this.
+- **Status-code side channels** — `403` vs `404` reveals existence; prefer `404`
+  under isolation.
+- **Cluster propagation** — federated search must not bypass the filter.
+
+## Testing
+
+- Unit: `visible_collections` / `check_permission` with namespace + explicit roles.
+- Integration per surface: two keys with disjoint namespaces; assert each sees/searches
+  only its own across `/admin/collections`, `/api/search`, `/_msearch`, every
+  `/collections/:c/*` route, and the ES-compat endpoints. Assert unauthorized
+  direct access returns `404` under isolation.
+- Regression: `isolation = false` leaves all current behavior unchanged.
+
+## Effort
+
+Core (steps 1–3) is roughly a day including tests — the model, default-deny
+`check_permission`, glob patterns, and filtered search already exist. Steps 4–5
+(ES-compat + cluster) carry most of the remaining effort and risk and can land
+incrementally behind the same `isolation` flag.

--- a/prism-storage/src/encrypted.rs
+++ b/prism-storage/src/encrypted.rs
@@ -289,14 +289,12 @@ impl EncryptedStorage {
                 msg: &data[HEADER_SIZE..],
                 aad: path_str.as_bytes(),
             };
-            self.cipher
-                .decrypt(nonce, payload)
-                .map_err(|e| {
-                    StorageError::Encryption(format!(
-                        "Decryption failed (wrong key, wrong path, or corrupted data): {}",
-                        e
-                    ))
-                })?
+            self.cipher.decrypt(nonce, payload).map_err(|e| {
+                StorageError::Encryption(format!(
+                    "Decryption failed (wrong key, wrong path, or corrupted data): {}",
+                    e
+                ))
+            })?
         };
 
         Ok(Bytes::from(plaintext))

--- a/prism-storage/src/local.rs
+++ b/prism-storage/src/local.rs
@@ -268,12 +268,12 @@ impl SegmentStorageSync for LocalStorage {
             std::fs::create_dir_all(parent)?;
         }
         let tmp_path = fs_path.with_extension(format!("tmp.{}", uuid::Uuid::new_v4()));
-        
+
         let mut f = std::fs::File::create(&tmp_path)?;
         use std::io::Write;
         f.write_all(data)?;
         f.sync_all()?;
-        
+
         std::fs::rename(&tmp_path, &fs_path)?;
         Ok(())
     }

--- a/prism/src/api/routes.rs
+++ b/prism/src/api/routes.rs
@@ -619,7 +619,10 @@ pub async fn list_pipelines(State(state): State<AppState>) -> Json<PipelineListR
 pub async fn get_document(
     Path((collection, id)): Path<(String, String)>,
     State(manager): State<Arc<CollectionManager>>,
+    user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
+    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
 ) -> Result<Json<Option<Document>>, StatusCode> {
+    authorize_collection(&user_ext, &checker_ext, &collection, crate::security::types::Permission::Read)?;
     manager
         .get(&collection, &id)
         .await
@@ -655,7 +658,11 @@ pub async fn list_documents(
     Path(collection): Path<String>,
     axum::extract::Query(query): axum::extract::Query<ScrollQuery>,
     State(manager): State<Arc<CollectionManager>>,
+    user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
+    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
 ) -> Result<Json<ScrollResponse>, (StatusCode, String)> {
+    authorize_collection(&user_ext, &checker_ext, &collection, crate::security::types::Permission::Read)
+        .map_err(|c| (c, "forbidden".to_string()))?;
     let stats = manager.stats(&collection).await.map_err(|e| {
         (
             StatusCode::NOT_FOUND,
@@ -1090,7 +1097,10 @@ pub struct CollectionSchemaResponse {
 pub async fn get_collection_schema(
     Path(collection): Path<String>,
     State(manager): State<Arc<CollectionManager>>,
+    user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
+    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
 ) -> Result<Json<CollectionSchemaResponse>, StatusCode> {
+    authorize_collection(&user_ext, &checker_ext, &collection, crate::security::types::Permission::Read)?;
     let schema = manager
         .get_schema(&collection)
         .ok_or(StatusCode::NOT_FOUND)?;
@@ -1139,7 +1149,10 @@ pub async fn get_collection_schema(
 pub async fn get_collection_schema_raw(
     Path(collection): Path<String>,
     State(manager): State<Arc<CollectionManager>>,
+    user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
+    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
 ) -> Result<Json<CollectionSchema>, StatusCode> {
+    authorize_collection(&user_ext, &checker_ext, &collection, crate::security::types::Permission::Read)?;
     let schema = manager
         .get_schema(&collection)
         .ok_or(StatusCode::NOT_FOUND)?;
@@ -1158,7 +1171,10 @@ pub struct CollectionStatsResponse {
 pub async fn get_collection_stats(
     Path(collection): Path<String>,
     State(manager): State<Arc<CollectionManager>>,
+    user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
+    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
 ) -> Result<Json<CollectionStatsResponse>, StatusCode> {
+    authorize_collection(&user_ext, &checker_ext, &collection, crate::security::types::Permission::Read)?;
     // Check if collection exists
     if manager.get_schema(&collection).is_none() {
         return Err(StatusCode::NOT_FOUND);
@@ -1307,8 +1323,11 @@ pub struct AggregateResponse {
 pub async fn aggregate(
     Path(collection): Path<String>,
     State(manager): State<Arc<CollectionManager>>,
+    user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
+    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
     Json(request): Json<AggregateRequest>,
 ) -> Result<Json<AggregateResponse>, StatusCode> {
+    authorize_collection(&user_ext, &checker_ext, &collection, crate::security::types::Permission::Search)?;
     let start = std::time::Instant::now();
 
     // Check if collection exists
@@ -1406,7 +1425,10 @@ pub async fn get_top_terms(
 pub async fn get_segments(
     Path(collection): Path<String>,
     State(manager): State<Arc<CollectionManager>>,
+    user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
+    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
 ) -> Result<Json<SegmentsInfo>, StatusCode> {
+    authorize_collection(&user_ext, &checker_ext, &collection, crate::security::types::Permission::Read)?;
     // Check if collection exists
     if manager.get_schema(&collection).is_none() {
         return Err(StatusCode::NOT_FOUND);
@@ -1520,8 +1542,11 @@ pub struct SuggestResponse {
 pub async fn suggest(
     Path(collection): Path<String>,
     State(manager): State<Arc<CollectionManager>>,
+    user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
+    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
     Json(req): Json<SuggestRequest>,
 ) -> Result<Json<SuggestResponse>, StatusCode> {
+    authorize_collection(&user_ext, &checker_ext, &collection, crate::security::types::Permission::Search)?;
     if manager.get_schema(&collection).is_none() {
         return Err(StatusCode::NOT_FOUND);
     }
@@ -1634,8 +1659,11 @@ pub struct MltRequest {
 pub async fn more_like_this(
     Path(collection): Path<String>,
     State(manager): State<Arc<CollectionManager>>,
+    user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
+    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
     Json(req): Json<MltRequest>,
 ) -> Result<Json<SearchResults>, StatusCode> {
+    authorize_collection(&user_ext, &checker_ext, &collection, crate::security::types::Permission::Search)?;
     if manager.get_schema(&collection).is_none() {
         return Err(StatusCode::NOT_FOUND);
     }

--- a/prism/src/api/routes.rs
+++ b/prism/src/api/routes.rs
@@ -158,7 +158,7 @@ async fn resolve_vector(
         Some(t) if !t.is_empty() => t,
         _ => return None,
     };
-    
+
     let is_hybrid = collections.iter().any(|&col| manager.is_hybrid(col));
 
     if is_hybrid {
@@ -178,7 +178,9 @@ async fn resolve_vector(
 /// collection names don't leak via status codes) or `403 Forbidden` otherwise.
 fn authorize_collection(
     user_ext: &Option<axum::extract::Extension<crate::security::types::AuthUser>>,
-    checker_ext: &Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
+    checker_ext: &Option<
+        axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>,
+    >,
     collection: &str,
     permission: crate::security::types::Permission,
 ) -> Result<(), StatusCode> {
@@ -205,7 +207,9 @@ pub async fn search(
     Path(collection): Path<String>,
     State(manager): State<Arc<CollectionManager>>,
     user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
-    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
+    checker_ext: Option<
+        axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>,
+    >,
     Json(request): Json<SearchRequest>,
 ) -> Result<Json<SearchResults>, (StatusCode, String)> {
     authorize_collection(
@@ -219,7 +223,13 @@ pub async fn search(
     let start = std::time::Instant::now();
 
     let has_vector = request.vector.is_some();
-    let vec_override = resolve_vector(&manager, &[&collection], request.vector, request.query.as_ref()).await;
+    let vec_override = resolve_vector(
+        &manager,
+        &[&collection],
+        request.vector,
+        request.query.as_ref(),
+    )
+    .await;
 
     let query = Query {
         query_string: request.query.clone().unwrap_or_default(),
@@ -319,19 +329,26 @@ pub async fn search(
 pub async fn simple_search(
     State(manager): State<Arc<CollectionManager>>,
     user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
-    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
+    checker_ext: Option<
+        axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>,
+    >,
     Json(request): Json<SimpleSearchRequest>,
 ) -> Result<Json<SimpleSearchResponse>, StatusCode> {
     let all_collections = manager.list_collections();
-    
-    let collections: Vec<String> = if let (Some(axum::extract::Extension(user)), Some(axum::extract::Extension(checker))) = (&user_ext, &checker_ext) {
-        all_collections
-            .into_iter()
-            .filter(|c| checker.check_permission(user, c, crate::security::types::Permission::Search))
-            .collect()
-    } else {
-        all_collections
-    };
+
+    let collections: Vec<String> =
+        if let (Some(axum::extract::Extension(user)), Some(axum::extract::Extension(checker))) =
+            (&user_ext, &checker_ext)
+        {
+            all_collections
+                .into_iter()
+                .filter(|c| {
+                    checker.check_permission(user, c, crate::security::types::Permission::Search)
+                })
+                .collect()
+        } else {
+            all_collections
+        };
 
     if collections.is_empty() {
         return Ok(Json(SimpleSearchResponse {
@@ -367,8 +384,14 @@ pub async fn simple_search(
             if !manager.collection_exists(&name) {
                 return Err(StatusCode::NOT_FOUND);
             }
-            if let (Some(axum::extract::Extension(user)), Some(axum::extract::Extension(checker))) = (&user_ext, &checker_ext) {
-                if !checker.check_permission(user, &name, crate::security::types::Permission::Search) {
+            if let (Some(axum::extract::Extension(user)), Some(axum::extract::Extension(checker))) =
+                (&user_ext, &checker_ext)
+            {
+                if !checker.check_permission(
+                    user,
+                    &name,
+                    crate::security::types::Permission::Search,
+                ) {
                     return Err(StatusCode::FORBIDDEN);
                 }
             }
@@ -620,9 +643,16 @@ pub async fn get_document(
     Path((collection, id)): Path<(String, String)>,
     State(manager): State<Arc<CollectionManager>>,
     user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
-    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
+    checker_ext: Option<
+        axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>,
+    >,
 ) -> Result<Json<Option<Document>>, StatusCode> {
-    authorize_collection(&user_ext, &checker_ext, &collection, crate::security::types::Permission::Read)?;
+    authorize_collection(
+        &user_ext,
+        &checker_ext,
+        &collection,
+        crate::security::types::Permission::Read,
+    )?;
     manager
         .get(&collection, &id)
         .await
@@ -659,10 +689,17 @@ pub async fn list_documents(
     axum::extract::Query(query): axum::extract::Query<ScrollQuery>,
     State(manager): State<Arc<CollectionManager>>,
     user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
-    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
+    checker_ext: Option<
+        axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>,
+    >,
 ) -> Result<Json<ScrollResponse>, (StatusCode, String)> {
-    authorize_collection(&user_ext, &checker_ext, &collection, crate::security::types::Permission::Read)
-        .map_err(|c| (c, "forbidden".to_string()))?;
+    authorize_collection(
+        &user_ext,
+        &checker_ext,
+        &collection,
+        crate::security::types::Permission::Read,
+    )
+    .map_err(|c| (c, "forbidden".to_string()))?;
     let stats = manager.stats(&collection).await.map_err(|e| {
         (
             StatusCode::NOT_FOUND,
@@ -734,17 +771,18 @@ use crate::schema::CollectionSchema;
 pub async fn list_collections(
     State(manager): State<Arc<CollectionManager>>,
     user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
-    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
+    checker_ext: Option<
+        axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>,
+    >,
 ) -> Json<CollectionsList> {
     let all = manager.list_collections();
     // When security is enabled, restrict the listing to collections the caller
     // may search — the same enforcement point used by simple_search. Without an
     // auth context (security disabled) the full list is returned unchanged.
     let collections = match (user_ext, checker_ext) {
-        (
-            Some(axum::extract::Extension(user)),
-            Some(axum::extract::Extension(checker)),
-        ) => checker.visible_collections(&user, all, crate::security::types::Permission::Search),
+        (Some(axum::extract::Extension(user)), Some(axum::extract::Extension(checker))) => {
+            checker.visible_collections(&user, all, crate::security::types::Permission::Search)
+        }
         _ => all,
     };
     Json(CollectionsList { collections })
@@ -1098,9 +1136,16 @@ pub async fn get_collection_schema(
     Path(collection): Path<String>,
     State(manager): State<Arc<CollectionManager>>,
     user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
-    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
+    checker_ext: Option<
+        axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>,
+    >,
 ) -> Result<Json<CollectionSchemaResponse>, StatusCode> {
-    authorize_collection(&user_ext, &checker_ext, &collection, crate::security::types::Permission::Read)?;
+    authorize_collection(
+        &user_ext,
+        &checker_ext,
+        &collection,
+        crate::security::types::Permission::Read,
+    )?;
     let schema = manager
         .get_schema(&collection)
         .ok_or(StatusCode::NOT_FOUND)?;
@@ -1150,9 +1195,16 @@ pub async fn get_collection_schema_raw(
     Path(collection): Path<String>,
     State(manager): State<Arc<CollectionManager>>,
     user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
-    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
+    checker_ext: Option<
+        axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>,
+    >,
 ) -> Result<Json<CollectionSchema>, StatusCode> {
-    authorize_collection(&user_ext, &checker_ext, &collection, crate::security::types::Permission::Read)?;
+    authorize_collection(
+        &user_ext,
+        &checker_ext,
+        &collection,
+        crate::security::types::Permission::Read,
+    )?;
     let schema = manager
         .get_schema(&collection)
         .ok_or(StatusCode::NOT_FOUND)?;
@@ -1172,9 +1224,16 @@ pub async fn get_collection_stats(
     Path(collection): Path<String>,
     State(manager): State<Arc<CollectionManager>>,
     user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
-    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
+    checker_ext: Option<
+        axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>,
+    >,
 ) -> Result<Json<CollectionStatsResponse>, StatusCode> {
-    authorize_collection(&user_ext, &checker_ext, &collection, crate::security::types::Permission::Read)?;
+    authorize_collection(
+        &user_ext,
+        &checker_ext,
+        &collection,
+        crate::security::types::Permission::Read,
+    )?;
     // Check if collection exists
     if manager.get_schema(&collection).is_none() {
         return Err(StatusCode::NOT_FOUND);
@@ -1324,10 +1383,17 @@ pub async fn aggregate(
     Path(collection): Path<String>,
     State(manager): State<Arc<CollectionManager>>,
     user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
-    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
+    checker_ext: Option<
+        axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>,
+    >,
     Json(request): Json<AggregateRequest>,
 ) -> Result<Json<AggregateResponse>, StatusCode> {
-    authorize_collection(&user_ext, &checker_ext, &collection, crate::security::types::Permission::Search)?;
+    authorize_collection(
+        &user_ext,
+        &checker_ext,
+        &collection,
+        crate::security::types::Permission::Search,
+    )?;
     let start = std::time::Instant::now();
 
     // Check if collection exists
@@ -1426,9 +1492,16 @@ pub async fn get_segments(
     Path(collection): Path<String>,
     State(manager): State<Arc<CollectionManager>>,
     user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
-    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
+    checker_ext: Option<
+        axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>,
+    >,
 ) -> Result<Json<SegmentsInfo>, StatusCode> {
-    authorize_collection(&user_ext, &checker_ext, &collection, crate::security::types::Permission::Read)?;
+    authorize_collection(
+        &user_ext,
+        &checker_ext,
+        &collection,
+        crate::security::types::Permission::Read,
+    )?;
     // Check if collection exists
     if manager.get_schema(&collection).is_none() {
         return Err(StatusCode::NOT_FOUND);
@@ -1543,10 +1616,17 @@ pub async fn suggest(
     Path(collection): Path<String>,
     State(manager): State<Arc<CollectionManager>>,
     user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
-    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
+    checker_ext: Option<
+        axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>,
+    >,
     Json(req): Json<SuggestRequest>,
 ) -> Result<Json<SuggestResponse>, StatusCode> {
-    authorize_collection(&user_ext, &checker_ext, &collection, crate::security::types::Permission::Search)?;
+    authorize_collection(
+        &user_ext,
+        &checker_ext,
+        &collection,
+        crate::security::types::Permission::Search,
+    )?;
     if manager.get_schema(&collection).is_none() {
         return Err(StatusCode::NOT_FOUND);
     }
@@ -1660,10 +1740,17 @@ pub async fn more_like_this(
     Path(collection): Path<String>,
     State(manager): State<Arc<CollectionManager>>,
     user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
-    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
+    checker_ext: Option<
+        axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>,
+    >,
     Json(req): Json<MltRequest>,
 ) -> Result<Json<SearchResults>, StatusCode> {
-    authorize_collection(&user_ext, &checker_ext, &collection, crate::security::types::Permission::Search)?;
+    authorize_collection(
+        &user_ext,
+        &checker_ext,
+        &collection,
+        crate::security::types::Permission::Search,
+    )?;
     if manager.get_schema(&collection).is_none() {
         return Err(StatusCode::NOT_FOUND);
     }
@@ -1734,10 +1821,14 @@ pub struct MultiSearchRequest {
 pub async fn multi_search(
     State(manager): State<Arc<CollectionManager>>,
     user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
-    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
+    checker_ext: Option<
+        axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>,
+    >,
     Json(request): Json<MultiSearchRequest>,
 ) -> Result<Json<MultiSearchResults>, StatusCode> {
-    if let (Some(axum::extract::Extension(user)), Some(axum::extract::Extension(checker))) = (user_ext, checker_ext) {
+    if let (Some(axum::extract::Extension(user)), Some(axum::extract::Extension(checker))) =
+        (user_ext, checker_ext)
+    {
         for c in &request.collections {
             if !checker.check_permission(&user, c, crate::security::types::Permission::Search) {
                 return Err(StatusCode::FORBIDDEN);
@@ -1748,7 +1839,13 @@ pub async fn multi_search(
     let start = std::time::Instant::now();
 
     let collection_refs: Vec<&str> = request.collections.iter().map(|s| s.as_str()).collect();
-    let vec_override = resolve_vector(&manager, &collection_refs, request.vector, request.query.as_ref()).await;
+    let vec_override = resolve_vector(
+        &manager,
+        &collection_refs,
+        request.vector,
+        request.query.as_ref(),
+    )
+    .await;
 
     let query = Query {
         query_string: request.query.clone().unwrap_or_default(),
@@ -1806,7 +1903,9 @@ pub async fn multi_index_search(
     Path(collections): Path<String>,
     State(manager): State<Arc<CollectionManager>>,
     user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
-    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
+    checker_ext: Option<
+        axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>,
+    >,
     Json(request): Json<SearchRequest>,
 ) -> Result<Json<MultiSearchResults>, StatusCode> {
     let start = std::time::Instant::now();
@@ -1822,7 +1921,9 @@ pub async fn multi_index_search(
         return Err(StatusCode::BAD_REQUEST);
     }
 
-    if let (Some(axum::extract::Extension(user)), Some(axum::extract::Extension(checker))) = (user_ext, checker_ext) {
+    if let (Some(axum::extract::Extension(user)), Some(axum::extract::Extension(checker))) =
+        (user_ext, checker_ext)
+    {
         for c in &collection_list {
             if !checker.check_permission(&user, c, crate::security::types::Permission::Search) {
                 return Err(StatusCode::FORBIDDEN);
@@ -1831,7 +1932,13 @@ pub async fn multi_index_search(
     }
 
     let collection_refs: Vec<&str> = collection_list.iter().map(|s| s.as_str()).collect();
-    let vec_override = resolve_vector(&manager, &collection_refs, request.vector, request.query.as_ref()).await;
+    let vec_override = resolve_vector(
+        &manager,
+        &collection_refs,
+        request.vector,
+        request.query.as_ref(),
+    )
+    .await;
 
     let query = Query {
         query_string: request.query.clone().unwrap_or_default(),
@@ -2634,10 +2741,14 @@ pub async fn graph_bfs(
     State(manager): State<Arc<CollectionManager>>,
     Json(request): Json<BfsRequest>,
 ) -> Result<Json<BfsResponse>, (StatusCode, String)> {
-    let graph = manager
-        .graph_backend(&collection)
-        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("No graph backend for collection '{}'", collection)))?;
-    let nodes = graph.bfs(&request.start, &request.edge_type, request.max_depth)
+    let graph = manager.graph_backend(&collection).ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            format!("No graph backend for collection '{}'", collection),
+        )
+    })?;
+    let nodes = graph
+        .bfs(&request.start, &request.edge_type, request.max_depth)
         .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
     let count = nodes.len();
     Ok(Json(BfsResponse { nodes, count }))
@@ -2649,11 +2760,15 @@ pub async fn graph_shortest_path(
     State(manager): State<Arc<CollectionManager>>,
     Json(request): Json<ShortestPathRequest>,
 ) -> Result<Json<ShortestPathResponse>, (StatusCode, String)> {
-    let graph = manager
-        .graph_backend(&collection)
-        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("No graph backend for collection '{}'", collection)))?;
+    let graph = manager.graph_backend(&collection).ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            format!("No graph backend for collection '{}'", collection),
+        )
+    })?;
     let edge_types = request.edge_types.as_deref();
-    let path = graph.shortest_path(&request.start, &request.target, edge_types)
+    let path = graph
+        .shortest_path(&request.start, &request.target, edge_types)
         .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
     let length = path.as_ref().map(|p| p.len().saturating_sub(1));
     Ok(Json(ShortestPathResponse { path, length }))

--- a/prism/src/api/routes.rs
+++ b/prism/src/api/routes.rs
@@ -691,8 +691,20 @@ use crate::schema::CollectionSchema;
 
 pub async fn list_collections(
     State(manager): State<Arc<CollectionManager>>,
+    user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
+    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
 ) -> Json<CollectionsList> {
-    let collections = manager.list_collections();
+    let all = manager.list_collections();
+    // When security is enabled, restrict the listing to collections the caller
+    // may search — the same enforcement point used by simple_search. Without an
+    // auth context (security disabled) the full list is returned unchanged.
+    let collections = match (user_ext, checker_ext) {
+        (
+            Some(axum::extract::Extension(user)),
+            Some(axum::extract::Extension(checker)),
+        ) => checker.visible_collections(&user, all, crate::security::types::Permission::Search),
+        _ => all,
+    };
     Json(CollectionsList { collections })
 }
 

--- a/prism/src/api/routes.rs
+++ b/prism/src/api/routes.rs
@@ -171,16 +171,51 @@ async fn resolve_vector(
     None
 }
 
+/// Authorize access to a single named collection.
+///
+/// With no auth context (security disabled) this is a no-op. When the caller
+/// lacks the permission, returns `404 Not Found` under isolation mode (so
+/// collection names don't leak via status codes) or `403 Forbidden` otherwise.
+fn authorize_collection(
+    user_ext: &Option<axum::extract::Extension<crate::security::types::AuthUser>>,
+    checker_ext: &Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
+    collection: &str,
+    permission: crate::security::types::Permission,
+) -> Result<(), StatusCode> {
+    if let (Some(axum::extract::Extension(user)), Some(axum::extract::Extension(checker))) =
+        (user_ext, checker_ext)
+    {
+        if !checker.check_permission(user, collection, permission) {
+            return Err(if checker.is_isolation() {
+                StatusCode::NOT_FOUND
+            } else {
+                StatusCode::FORBIDDEN
+            });
+        }
+    }
+    Ok(())
+}
+
 #[tracing::instrument(
     name = "search",
-    skip(manager, request),
+    skip(manager, request, user_ext, checker_ext),
     fields(collection = %collection, search_type = "text")
 )]
 pub async fn search(
     Path(collection): Path<String>,
     State(manager): State<Arc<CollectionManager>>,
+    user_ext: Option<axum::extract::Extension<crate::security::types::AuthUser>>,
+    checker_ext: Option<axum::extract::Extension<Arc<crate::security::permissions::PermissionChecker>>>,
     Json(request): Json<SearchRequest>,
 ) -> Result<Json<SearchResults>, (StatusCode, String)> {
+    authorize_collection(
+        &user_ext,
+        &checker_ext,
+        &collection,
+        crate::security::types::Permission::Search,
+    )
+    .map_err(|c| (c, "forbidden".to_string()))?;
+
     let start = std::time::Instant::now();
 
     let has_vector = request.vector.is_some();

--- a/prism/src/api/server.rs
+++ b/prism/src/api/server.rs
@@ -57,7 +57,7 @@ async fn metrics_middleware(
     response
 }
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
@@ -529,7 +529,9 @@ impl ApiServer {
         // Background indexing queue (capacity 1000 jobs)
         let (index_queue_tx, mut index_queue_rx) = mpsc::channel::<IndexJob>(1000);
 
-        let dlq = self.data_dir.as_ref().map(|d| DiskDlq { path: d.join("dlq.jsonl") });
+        let dlq = self.data_dir.as_ref().map(|d| DiskDlq {
+            path: d.join("dlq.jsonl"),
+        });
         if let Some(ref d) = dlq {
             if let Some(parent) = d.path.parent() {
                 let _ = tokio::fs::create_dir_all(parent).await;

--- a/prism/src/backends/graph/backend.rs
+++ b/prism/src/backends/graph/backend.rs
@@ -60,7 +60,9 @@ impl ShardedGraphBackend {
     pub async fn initialize(&self) -> Result<()> {
         let mut needs_migration = false;
         if self.num_shards > 1 {
-            let meta_path = crate::storage::StoragePath::graph(&self.collection, "meta", "hash_version.json").unwrap();
+            let meta_path =
+                crate::storage::StoragePath::graph(&self.collection, "meta", "hash_version.json")
+                    .unwrap();
             if let Some(storage) = &self.shards[0].storage {
                 match storage.read_vec(&meta_path).await {
                     Ok(bytes) => {
@@ -75,9 +77,12 @@ impl ShardedGraphBackend {
                 }
             }
         }
-        
+
         if needs_migration {
-            tracing::info!("Migrating graph backend to format version 1 (stable hashing) for collection {}", self.collection);
+            tracing::info!(
+                "Migrating graph backend to format version 1 (stable hashing) for collection {}",
+                self.collection
+            );
             let mut all_nodes = Vec::new();
             let mut all_edges = Vec::new();
             for shard in &self.shards {
@@ -95,7 +100,7 @@ impl ShardedGraphBackend {
                 }
                 shard.clear().await?;
             }
-            
+
             for node in all_nodes {
                 let idx = self.shard_idx(&node.id);
                 self.shards[idx].add_node(node).await?;
@@ -104,9 +109,14 @@ impl ShardedGraphBackend {
                 let idx = self.shard_idx(&edge.from);
                 self.shards[idx].add_edge(edge).await?;
             }
-            
+
             if let Some(storage) = &self.shards[0].storage {
-                let meta_path = crate::storage::StoragePath::graph(&self.collection, "meta", "hash_version.json").unwrap();
+                let meta_path = crate::storage::StoragePath::graph(
+                    &self.collection,
+                    "meta",
+                    "hash_version.json",
+                )
+                .unwrap();
                 let _ = storage.write_bytes(&meta_path, b"1").await;
             }
             return Ok(());
@@ -177,7 +187,12 @@ impl ShardedGraphBackend {
     }
 
     /// BFS traversal — entirely local within the start node's shard.
-    pub fn bfs(&self, start: &str, edge_type: &str, max_depth: usize) -> crate::Result<Vec<String>> {
+    pub fn bfs(
+        &self,
+        start: &str,
+        edge_type: &str,
+        max_depth: usize,
+    ) -> crate::Result<Vec<String>> {
         if self.scope == GraphScope::Collection {
             return Err(crate::error::Error::InvalidQuery(
                 "Cross-shard traversal (scope=Collection) is not yet supported for BFS".to_string(),
@@ -196,7 +211,8 @@ impl ShardedGraphBackend {
     ) -> crate::Result<Option<Vec<String>>> {
         if self.scope == GraphScope::Collection {
             return Err(crate::error::Error::InvalidQuery(
-                "Cross-shard traversal (scope=Collection) is not yet supported for shortest_path".to_string(),
+                "Cross-shard traversal (scope=Collection) is not yet supported for shortest_path"
+                    .to_string(),
             ));
         }
         let start_idx = self.shard_idx(start);

--- a/prism/src/backends/graph/shard.rs
+++ b/prism/src/backends/graph/shard.rs
@@ -67,7 +67,11 @@ pub enum GraphOp {
     AddNode(GraphNode),
     RemoveNode(String),
     AddEdge(GraphEdge),
-    RemoveEdge { from: String, to: String, edge_type: Option<String> },
+    RemoveEdge {
+        from: String,
+        to: String,
+        edge_type: Option<String>,
+    },
 }
 
 /// A single graph shard with SegmentStorage support.
@@ -123,7 +127,8 @@ impl GraphShard {
             }
 
             // Replay WAL
-            let wal_prefix = StoragePath::graph(&self.collection, &self.shard_name, "wal/").unwrap();
+            let wal_prefix =
+                StoragePath::graph(&self.collection, &self.shard_name, "wal/").unwrap();
             if let Ok(mut files) = storage.list(&wal_prefix).await {
                 files.sort_by(|a, b| a.path.to_string().cmp(&b.path.to_string()));
                 let mut replayed = 0;
@@ -174,13 +179,20 @@ impl GraphShard {
                     weight: edge.weight,
                 };
                 let list = edges.entry(edge.from).or_default();
-                if let Some(existing) = list.iter_mut().find(|e| e.to == entry.to && e.edge_type == entry.edge_type) {
+                if let Some(existing) = list
+                    .iter_mut()
+                    .find(|e| e.to == entry.to && e.edge_type == entry.edge_type)
+                {
                     existing.weight = entry.weight;
                 } else {
                     list.push(entry);
                 }
             }
-            GraphOp::RemoveEdge { from, to, edge_type } => {
+            GraphOp::RemoveEdge {
+                from,
+                to,
+                edge_type,
+            } => {
                 let mut edges = self.edges.write();
                 if let Some(edge_list) = edges.get_mut(&from) {
                     edge_list.retain(|e| {
@@ -201,13 +213,32 @@ impl GraphShard {
     async fn append_wal(&self, op: GraphOp) -> Result<()> {
         if let Some(ref storage) = self.storage {
             let data = serde_json::to_vec(&vec![op]).unwrap();
-            let wal_filename = format!("{}_{}.json", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis(), uuid::Uuid::new_v4());
-            let wal_path = StoragePath::graph(&self.collection, &self.shard_name, &format!("wal/{}", wal_filename)).unwrap();
-            storage.write_bytes(&wal_path, &data).await.map_err(|e| Error::Storage(e.to_string()))?;
+            let wal_filename = format!(
+                "{}_{}.json",
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis(),
+                uuid::Uuid::new_v4()
+            );
+            let wal_path = StoragePath::graph(
+                &self.collection,
+                &self.shard_name,
+                &format!("wal/{}", wal_filename),
+            )
+            .unwrap();
+            storage
+                .write_bytes(&wal_path, &data)
+                .await
+                .map_err(|e| Error::Storage(e.to_string()))?;
 
-            let current = self.unflushed_ops.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+            let current = self
+                .unflushed_ops
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                + 1;
             if self.wal_config.batch_size > 0 && current >= self.wal_config.batch_size {
-                self.unflushed_ops.store(0, std::sync::atomic::Ordering::SeqCst);
+                self.unflushed_ops
+                    .store(0, std::sync::atomic::Ordering::SeqCst);
                 self.persist().await?;
             }
         }
@@ -265,7 +296,14 @@ impl GraphShard {
         // Just apply it unconditionally, graph ops are idempotent or safe
         let existed = {
             let edges = self.edges.read();
-            edges.get(from).map(|l| l.iter().any(|e| e.to == to && (edge_type.is_none() || e.edge_type == edge_type.unwrap()))).unwrap_or(false)
+            edges
+                .get(from)
+                .map(|l| {
+                    l.iter().any(|e| {
+                        e.to == to && (edge_type.is_none() || e.edge_type == edge_type.unwrap())
+                    })
+                })
+                .unwrap_or(false)
         };
         if existed {
             self.apply_op(GraphOp::RemoveEdge {
@@ -277,7 +315,8 @@ impl GraphShard {
                 from: from.to_string(),
                 to: to.to_string(),
                 edge_type: edge_type.map(String::from),
-            }).await?;
+            })
+            .await?;
         }
         Ok(existed)
     }
@@ -614,7 +653,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_and_get_node() {
-        let shard = GraphShard::new(0, "test", "default", &test_edge_configs(), None, crate::schema::types::WalConfig::default());
+        let shard = GraphShard::new(
+            0,
+            "test",
+            "default",
+            &test_edge_configs(),
+            None,
+            crate::schema::types::WalConfig::default(),
+        );
 
         let node = GraphNode {
             id: "n1".to_string(),
@@ -632,7 +678,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_and_get_edges() {
-        let shard = GraphShard::new(0, "test", "default", &test_edge_configs(), None, crate::schema::types::WalConfig::default());
+        let shard = GraphShard::new(
+            0,
+            "test",
+            "default",
+            &test_edge_configs(),
+            None,
+            crate::schema::types::WalConfig::default(),
+        );
 
         shard
             .add_node(GraphNode {
@@ -670,7 +723,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_bfs() {
-        let shard = GraphShard::new(0, "test", "default", &test_edge_configs(), None, crate::schema::types::WalConfig::default());
+        let shard = GraphShard::new(
+            0,
+            "test",
+            "default",
+            &test_edge_configs(),
+            None,
+            crate::schema::types::WalConfig::default(),
+        );
 
         for id in &["a", "b", "c", "d"] {
             shard
@@ -704,7 +764,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_shortest_path() {
-        let shard = GraphShard::new(0, "test", "default", &test_edge_configs(), None, crate::schema::types::WalConfig::default());
+        let shard = GraphShard::new(
+            0,
+            "test",
+            "default",
+            &test_edge_configs(),
+            None,
+            crate::schema::types::WalConfig::default(),
+        );
 
         for id in &["a", "b", "c", "d"] {
             shard
@@ -818,7 +885,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_stats() {
-        let shard = GraphShard::new(0, "test", "default", &test_edge_configs(), None, crate::schema::types::WalConfig::default());
+        let shard = GraphShard::new(
+            0,
+            "test",
+            "default",
+            &test_edge_configs(),
+            None,
+            crate::schema::types::WalConfig::default(),
+        );
 
         shard
             .add_node(GraphNode {
@@ -856,7 +930,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_invalid_edge_type() {
-        let shard = GraphShard::new(0, "test", "default", &test_edge_configs(), None, crate::schema::types::WalConfig::default());
+        let shard = GraphShard::new(
+            0,
+            "test",
+            "default",
+            &test_edge_configs(),
+            None,
+            crate::schema::types::WalConfig::default(),
+        );
 
         let result = shard
             .add_edge(GraphEdge {

--- a/prism/src/backends/graph/shard.rs
+++ b/prism/src/backends/graph/shard.rs
@@ -76,6 +76,7 @@ pub enum GraphOp {
 
 /// A single graph shard with SegmentStorage support.
 pub struct GraphShard {
+    #[allow(dead_code)]
     pub(crate) shard_id: u32,
     pub(crate) collection: String,
     pub(crate) shard_name: String,
@@ -224,7 +225,7 @@ impl GraphShard {
             let wal_path = StoragePath::graph(
                 &self.collection,
                 &self.shard_name,
-                &format!("wal/{}", wal_filename),
+                format!("wal/{}", wal_filename),
             )
             .unwrap();
             storage

--- a/prism/src/backends/graph/shard.rs
+++ b/prism/src/backends/graph/shard.rs
@@ -131,7 +131,7 @@ impl GraphShard {
             let wal_prefix =
                 StoragePath::graph(&self.collection, &self.shard_name, "wal/").unwrap();
             if let Ok(mut files) = storage.list(&wal_prefix).await {
-                files.sort_by(|a, b| a.path.to_string().cmp(&b.path.to_string()));
+                files.sort_by_key(|f| f.path.to_string());
                 let mut replayed = 0;
                 for file in files {
                     if let Ok(data) = storage.read(&file.path).await {

--- a/prism/src/backends/hybrid.rs
+++ b/prism/src/backends/hybrid.rs
@@ -293,7 +293,10 @@ impl SearchBackend for HybridSearchCoordinator {
 
     async fn search(&self, collection: &str, query: Query) -> Result<SearchResults> {
         // Look for explicit vector in the query struct. (Legacy fallback: parse query_string just in case)
-        let maybe_vec = query.vector.clone().or_else(|| serde_json::from_str(&query.query_string).ok());
+        let maybe_vec = query
+            .vector
+            .clone()
+            .or_else(|| serde_json::from_str(&query.query_string).ok());
 
         let (tres, vres) = if let Some(vec) = maybe_vec {
             // Run vector search and text search in parallel

--- a/prism/src/backends/hybrid.rs
+++ b/prism/src/backends/hybrid.rs
@@ -107,6 +107,7 @@ impl HybridSearchCoordinator {
     }
 
     /// Weighted merge with configurable normalization strategy.
+    #[allow(clippy::too_many_arguments)]
     pub fn merge_weighted_with_normalization(
         text: SearchResults,
         vector: SearchResults,

--- a/prism/src/backends/vector/backend.rs
+++ b/prism/src/backends/vector/backend.rs
@@ -174,7 +174,8 @@ impl VectorBackend {
                     let persisted_dims = restored.shards.first().map(|s| s.dimensions).unwrap_or(0);
                     let persisted_metric = restored.shards.first().map(|s| s.metric.clone());
 
-                    let dims_mismatch = persisted_dims != vector_config.dimension && persisted_dims > 0;
+                    let dims_mismatch =
+                        persisted_dims != vector_config.dimension && persisted_dims > 0;
                     let metric_mismatch = persisted_metric.map_or(false, |m| m != metric);
 
                     if dims_mismatch || metric_mismatch {
@@ -274,7 +275,7 @@ impl VectorBackend {
             let ep = self.embedding_provider.read();
             ep.clone()
         };
-        
+
         if let Some(provider) = provider {
             let result = provider
                 .embed(text)
@@ -306,10 +307,9 @@ impl VectorBackend {
         };
 
         if let Some(provider) = provider {
-            let result = provider
-                .embed_batch(texts)
-                .await
-                .map_err(|e| crate::error::Error::Backend(format!("Batch embedding failed: {}", e)));
+            let result = provider.embed_batch(texts).await.map_err(|e| {
+                crate::error::Error::Backend(format!("Batch embedding failed: {}", e))
+            });
 
             let duration = start.elapsed().as_secs_f64();
             let status = if result.is_ok() { "ok" } else { "error" };
@@ -337,7 +337,7 @@ impl VectorBackend {
         let query_vector = self.embed_text(text).await?;
 
         let query = Query {
-        vector: None,
+            vector: None,
             query_string: serde_json::to_string(&query_vector)
                 .map_err(|e| crate::error::Error::Backend(format!("JSON error: {}", e)))?,
             fields: vec![],
@@ -422,7 +422,11 @@ impl VectorBackend {
         let mut files_to_delete = Vec::new();
 
         for file in files {
-            let data = self.storage.read(&file.path).await.map_err(|e| crate::error::Error::Storage(e.to_string()))?;
+            let data = self
+                .storage
+                .read(&file.path)
+                .await
+                .map_err(|e| crate::error::Error::Storage(e.to_string()))?;
             let docs: Vec<Document> = match serde_json::from_slice(&data) {
                 Ok(d) => d,
                 Err(e) => {
@@ -431,7 +435,11 @@ impl VectorBackend {
                 }
             };
 
-            let target_field = sharded.shards.first().map(|s| s.embedding_target_field.clone()).unwrap_or_else(|| "embedding".to_string());
+            let target_field = sharded
+                .shards
+                .first()
+                .map(|s| s.embedding_target_field.clone())
+                .unwrap_or_else(|| "embedding".to_string());
             let dimensions = sharded.shards.first().map(|s| s.dimensions).unwrap_or(0);
 
             for doc in docs {
@@ -439,7 +447,12 @@ impl VectorBackend {
                     if let Ok(vector) = serde_json::from_value::<Vec<f32>>(vector_value.clone()) {
                         if vector.len() == dimensions {
                             let shard_id = shard_for_doc(&doc.id, sharded.num_shards) as usize;
-                            if let Err(e) = sharded.shards[shard_id].index(&doc.id, &vector, doc.fields.clone(), sharded.compaction_config.max_active_segment_size) {
+                            if let Err(e) = sharded.shards[shard_id].index(
+                                &doc.id,
+                                &vector,
+                                doc.fields.clone(),
+                                sharded.compaction_config.max_active_segment_size,
+                            ) {
                                 tracing::warn!(error = %e, "Failed to replay doc into shard");
                             }
                         }
@@ -462,7 +475,11 @@ impl VectorBackend {
                 }
             }
 
-            tracing::info!(collection, replayed, "Replayed vector WAL files and snapshotted");
+            tracing::info!(
+                collection,
+                replayed,
+                "Replayed vector WAL files and snapshotted"
+            );
         }
         Ok(())
     }
@@ -540,10 +557,21 @@ impl SearchBackend for VectorBackend {
         }
 
         // Write WAL first for durability
-        let wal_data = serde_json::to_vec(&docs).map_err(|e| crate::error::Error::Schema(e.to_string()))?;
-        let wal_filename = format!("{}_{}.json", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis(), uuid::Uuid::new_v4());
+        let wal_data =
+            serde_json::to_vec(&docs).map_err(|e| crate::error::Error::Schema(e.to_string()))?;
+        let wal_filename = format!(
+            "{}_{}.json",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+            uuid::Uuid::new_v4()
+        );
         let wal_path = Self::wal_file_path(collection, &wal_filename);
-        self.storage.write_bytes(&wal_path, &wal_data).await.map_err(|e| crate::error::Error::Storage(e.to_string()))?;
+        self.storage
+            .write_bytes(&wal_path, &wal_data)
+            .await
+            .map_err(|e| crate::error::Error::Storage(e.to_string()))?;
 
         // Index documents with embeddings, routing to shards by doc ID hash
         let (needs_flush, save_lock_opt) = {
@@ -578,10 +606,18 @@ impl SearchBackend for VectorBackend {
                 }
 
                 let shard_id = shard_for_doc(&doc.id, sharded.num_shards) as usize;
-                sharded.shards[shard_id].index(&doc.id, &vector, doc.fields, sharded.compaction_config.max_active_segment_size)?;
+                sharded.shards[shard_id].index(
+                    &doc.id,
+                    &vector,
+                    doc.fields,
+                    sharded.compaction_config.max_active_segment_size,
+                )?;
             }
 
-            let current_unflushed = sharded.unflushed_inserts.fetch_add(docs_len, Ordering::SeqCst) + docs_len;
+            let current_unflushed = sharded
+                .unflushed_inserts
+                .fetch_add(docs_len, Ordering::SeqCst)
+                + docs_len;
             let batch_size = sharded.wal_config.batch_size;
 
             if batch_size > 0 && current_unflushed >= batch_size {
@@ -727,7 +763,7 @@ impl SearchBackend for VectorBackend {
         };
 
         let _guard = save_lock_opt.lock().await;
-        
+
         let data = {
             let indexes = self.indexes.read();
             if let Some(sharded) = indexes.get(collection) {
@@ -799,22 +835,22 @@ fn deserialize_sharded_index(
     vector_config: &crate::schema::types::VectorBackendConfig,
 ) -> Result<ShardedVectorIndex> {
     let persisted: PersistedShardedIndex = serde_json::from_slice(bytes)?;
-    
+
     if persisted.hash_version == 0 && persisted.num_shards > 1 {
         tracing::info!("Migrating sharded index to format version 1 (stable hashing)");
-        
+
         let mut old_shards = Vec::new();
         for shard_p in persisted.shards {
             old_shards.push(VectorShard::from_persisted(shard_p)?);
         }
-        
+
         let mut new_shards = Vec::new();
         if !old_shards.is_empty() {
             let dimensions = old_shards[0].dimensions;
             let metric = old_shards[0].metric.clone();
             let source_field = old_shards[0].embedding_source_field.clone();
             let target_field = old_shards[0].embedding_target_field.clone();
-            
+
             for i in 0..persisted.num_shards {
                 new_shards.push(VectorShard::new(
                     i as u32,
@@ -827,21 +863,36 @@ fn deserialize_sharded_index(
                     target_field.clone(),
                 )?);
             }
-            
+
             for old_shard in old_shards {
                 for seg in &old_shard.sealed_segments {
                     for (id, vec, fields) in seg.extract_all() {
-                        let new_shard_idx = crate::backends::vector::shard::shard_for_doc(&id, persisted.num_shards) as usize;
-                        new_shards[new_shard_idx].index(&id, &vec, fields, persisted.compaction_config.max_active_segment_size)?;
+                        let new_shard_idx = crate::backends::vector::shard::shard_for_doc(
+                            &id,
+                            persisted.num_shards,
+                        ) as usize;
+                        new_shards[new_shard_idx].index(
+                            &id,
+                            &vec,
+                            fields,
+                            persisted.compaction_config.max_active_segment_size,
+                        )?;
                     }
                 }
                 for (id, vec, fields) in old_shard.active_segment.extract_all() {
-                    let new_shard_idx = crate::backends::vector::shard::shard_for_doc(&id, persisted.num_shards) as usize;
-                    new_shards[new_shard_idx].index(&id, &vec, fields, persisted.compaction_config.max_active_segment_size)?;
+                    let new_shard_idx =
+                        crate::backends::vector::shard::shard_for_doc(&id, persisted.num_shards)
+                            as usize;
+                    new_shards[new_shard_idx].index(
+                        &id,
+                        &vec,
+                        fields,
+                        persisted.compaction_config.max_active_segment_size,
+                    )?;
                 }
             }
         }
-        
+
         return Ok(ShardedVectorIndex {
             shards: new_shards,
             num_shards: persisted.num_shards,
@@ -1009,7 +1060,7 @@ mod tests {
 
         // Search
         let query = Query {
-        vector: None,
+            vector: None,
             query_string: serde_json::to_string(&vec![1.0f32, 0.0, 0.0, 0.0]).unwrap(),
             fields: vec![],
             limit: 10,
@@ -1099,7 +1150,7 @@ mod tests {
         backend.index("test", docs).await.unwrap();
 
         let query = Query {
-        vector: None,
+            vector: None,
             query_string: serde_json::to_string(&vec![1.0f32, 0.0, 0.0, 0.0]).unwrap(),
             fields: vec![],
             limit: 10,

--- a/prism/src/backends/vector/backend.rs
+++ b/prism/src/backends/vector/backend.rs
@@ -172,11 +172,11 @@ impl VectorBackend {
                 Ok(restored) => {
                     // Verify persisted dimensions match schema
                     let persisted_dims = restored.shards.first().map(|s| s.dimensions).unwrap_or(0);
-                    let persisted_metric = restored.shards.first().map(|s| s.metric.clone());
+                    let persisted_metric = restored.shards.first().map(|s| s.metric);
 
                     let dims_mismatch =
                         persisted_dims != vector_config.dimension && persisted_dims > 0;
-                    let metric_mismatch = persisted_metric.map_or(false, |m| m != metric);
+                    let metric_mismatch = persisted_metric.is_some_and(|m| m != metric);
 
                     if dims_mismatch || metric_mismatch {
                         tracing::warn!(
@@ -374,7 +374,7 @@ impl VectorBackend {
     }
 
     fn wal_file_path(collection: &str, file_name: &str) -> StoragePath {
-        StoragePath::vector(collection, "default", &format!("wal/{}", file_name)).unwrap()
+        StoragePath::vector(collection, "default", format!("wal/{}", file_name)).unwrap()
     }
 
     async fn save_index(&self, collection: &str, data: &[u8]) -> Result<()> {
@@ -847,7 +847,7 @@ fn deserialize_sharded_index(
         let mut new_shards = Vec::new();
         if !old_shards.is_empty() {
             let dimensions = old_shards[0].dimensions;
-            let metric = old_shards[0].metric.clone();
+            let metric = old_shards[0].metric;
             let source_field = old_shards[0].embedding_source_field.clone();
             let target_field = old_shards[0].embedding_target_field.clone();
 
@@ -855,7 +855,7 @@ fn deserialize_sharded_index(
                 new_shards.push(VectorShard::new(
                     i as u32,
                     dimensions,
-                    metric.clone(),
+                    metric,
                     vector_config.hnsw_m,
                     vector_config.hnsw_ef_construction,
                     vector_config.hnsw_ef_search,

--- a/prism/src/backends/vector/backend.rs
+++ b/prism/src/backends/vector/backend.rs
@@ -416,7 +416,7 @@ impl VectorBackend {
         }
 
         // Sort by path to replay in chronological order (since we use timestamp in filename)
-        files.sort_by(|a, b| a.path.to_string().cmp(&b.path.to_string()));
+        files.sort_by_key(|f| f.path.to_string());
 
         let mut replayed = 0;
         let mut files_to_delete = Vec::new();

--- a/prism/src/backends/vector/compaction.rs
+++ b/prism/src/backends/vector/compaction.rs
@@ -114,7 +114,12 @@ mod tests {
                 serde_json::to_value(vec![i as f32, 0.0, 0.0, 0.0]).unwrap(),
             );
             shard
-                .index(&format!("doc{}", i), &[i as f32, 0.0, 0.0, 0.0], fields, 10000)
+                .index(
+                    &format!("doc{}", i),
+                    &[i as f32, 0.0, 0.0, 0.0],
+                    fields,
+                    10000,
+                )
                 .unwrap();
         }
 

--- a/prism/src/backends/vector/index.rs
+++ b/prism/src/backends/vector/index.rs
@@ -374,9 +374,9 @@ impl InstantDistanceAdapter {
             points.push(p.1.clone());
             keys.push(values[i]);
         }
-        
+
         let built_size = keys.len();
-        
+
         // Append unbuilt points from meta
         keys.extend(meta.unbuilt_keys);
         points.extend(meta.unbuilt_points);
@@ -527,7 +527,6 @@ impl InstantDistanceAdapter {
         adapter.rebuild()?;
         Ok(adapter)
     }
-
 }
 
 // When vector-instant is enabled (including when both are enabled), prefer it.

--- a/prism/src/backends/vector/shard.rs
+++ b/prism/src/backends/vector/shard.rs
@@ -304,7 +304,9 @@ mod tests {
         shard
             .index("doc1", &[1.0, 0.0, 0.0, 0.0], fields.clone(), 10000)
             .unwrap();
-        shard.index("doc2", &[0.0, 1.0, 0.0, 0.0], fields, 10000).unwrap();
+        shard
+            .index("doc2", &[0.0, 1.0, 0.0, 0.0], fields, 10000)
+            .unwrap();
 
         let results = shard.search(&[1.0, 0.0, 0.0, 0.0], 2).unwrap();
         assert!(!results.is_empty());

--- a/prism/src/collection/manager.rs
+++ b/prism/src/collection/manager.rs
@@ -878,7 +878,7 @@ impl CollectionManager {
         // Text-only search
         if !has_vector || vector.is_none() {
             let query = Query {
-        vector: None,
+                vector: None,
                 query_string: text_query.to_string(),
                 fields: vec![],
                 limit,
@@ -902,7 +902,7 @@ impl CollectionManager {
         if !has_text {
             let vec = vector.unwrap();
             let query = Query {
-        vector: None,
+                vector: None,
                 query_string: serde_json::to_string(&vec).unwrap_or_default(),
                 fields: vec![],
                 limit,
@@ -926,7 +926,7 @@ impl CollectionManager {
         let vec = vector.unwrap();
 
         let text_query_obj = Query {
-        vector: None,
+            vector: None,
             query_string: text_query.to_string(),
             fields: vec![],
             limit,
@@ -945,7 +945,7 @@ impl CollectionManager {
         };
 
         let vec_query_obj = Query {
-        vector: None,
+            vector: None,
             query_string: serde_json::to_string(&vec).unwrap_or_default(),
             fields: vec![],
             limit,
@@ -1506,7 +1506,7 @@ backends:
 
         // Search
         let query = Query {
-        vector: None,
+            vector: None,
             query_string: "rust".to_string(),
             fields: vec!["title".to_string(), "content".to_string()],
             limit: 10,
@@ -2110,7 +2110,7 @@ backends:
 
         // Multi-search across both collections
         let query = Query {
-        vector: None,
+            vector: None,
             query_string: "rust".to_string(),
             fields: vec!["title".to_string()],
             limit: 10,

--- a/prism/src/config/mod.rs
+++ b/prism/src/config/mod.rs
@@ -215,6 +215,11 @@ pub struct SecurityConfig {
     pub roles: HashMap<String, RoleConfig>,
     #[serde(default)]
     pub audit: AuditConfig,
+    /// Opt-in isolation mode. When true, an api key's `namespace` implicitly
+    /// grants read+search on `<namespace>*`, and enumeration/search surfaces
+    /// restrict results to what the caller may see. Off by default.
+    #[serde(default)]
+    pub isolation: bool,
 }
 
 impl Default for SecurityConfig {
@@ -224,6 +229,7 @@ impl Default for SecurityConfig {
             api_keys: Vec::new(),
             roles: HashMap::new(),
             audit: AuditConfig::default(),
+            isolation: false,
         }
     }
 }
@@ -234,6 +240,10 @@ pub struct ApiKeyConfig {
     pub name: String,
     #[serde(default)]
     pub roles: Vec<String>,
+    /// Collection namespace for this key. Under `isolation` mode this implicitly
+    /// grants read+search on `<namespace>*` without needing an explicit role.
+    #[serde(default)]
+    pub namespace: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/prism/src/mcp/tools.rs
+++ b/prism/src/mcp/tools.rs
@@ -141,7 +141,7 @@ impl McpTool for SearchTool {
         let limit = params.get("limit").and_then(|v| v.as_u64()).unwrap_or(10) as usize;
 
         let query = Query {
-        vector: None,
+            vector: None,
             query_string: query_string.to_string(),
             fields: vec![],
             limit,

--- a/prism/src/security/middleware.rs
+++ b/prism/src/security/middleware.rs
@@ -10,11 +10,7 @@ use super::types::Permission;
 /// without an API key, because the UI has to render before it can authenticate
 /// its own API calls. The UI's data requests (`/api/*`, `/collections/*`) still
 /// go through auth normally.
-const AUTH_WHITELIST: &[&str] = &[
-    "/health",
-    "/stats/server",
-    "/ui",
-];
+const AUTH_WHITELIST: &[&str] = &["/health", "/stats/server", "/ui"];
 
 /// Whether a path is publicly reachable without authentication.
 ///

--- a/prism/src/security/middleware.rs
+++ b/prism/src/security/middleware.rs
@@ -205,9 +205,11 @@ mod tests {
                 key: "k".to_string(),
                 name: "u".to_string(),
                 roles: vec![role.to_string()],
+                namespace: None,
             }],
             roles,
             audit: Default::default(),
+            isolation: false,
         };
         PermissionChecker::new(&config)
     }
@@ -217,6 +219,7 @@ mod tests {
             name: "u".to_string(),
             roles: vec![role.to_string()],
             key_prefix: "k".to_string(),
+            namespace: None,
         }
     }
 

--- a/prism/src/security/permissions.rs
+++ b/prism/src/security/permissions.rs
@@ -5,17 +5,26 @@ use subtle::ConstantTimeEq;
 
 pub struct PermissionChecker {
     /// Stored API keys with metadata for constant-time lookup
-    keys: Vec<(String, String, Vec<String>)>, // (key, name, roles)
+    keys: Vec<(String, String, Vec<String>, Option<String>)>, // (key, name, roles, namespace)
     /// Role name -> collection patterns -> permissions
     roles: HashMap<String, Vec<(String, Vec<String>)>>,
+    /// Opt-in isolation mode (namespace implicit grants + default-deny surfaces).
+    isolation: bool,
 }
 
 impl PermissionChecker {
     pub fn new(config: &SecurityConfig) -> Self {
-        let keys: Vec<(String, String, Vec<String>)> = config
+        let keys: Vec<(String, String, Vec<String>, Option<String>)> = config
             .api_keys
             .iter()
-            .map(|ak| (ak.key.clone(), ak.name.clone(), ak.roles.clone()))
+            .map(|ak| {
+                (
+                    ak.key.clone(),
+                    ak.name.clone(),
+                    ak.roles.clone(),
+                    ak.namespace.clone(),
+                )
+            })
             .collect();
 
         let roles: HashMap<String, Vec<(String, Vec<String>)>> = config
@@ -31,7 +40,11 @@ impl PermissionChecker {
             })
             .collect();
 
-        Self { keys, roles }
+        Self {
+            keys,
+            roles,
+            isolation: config.isolation,
+        }
     }
 
     /// Authenticate an API key using constant-time comparison.
@@ -41,21 +54,21 @@ impl PermissionChecker {
     /// could leak key prefixes.
     pub fn authenticate(&self, api_key: &str) -> Option<AuthUser> {
         let input_bytes = api_key.as_bytes();
-        let mut matched: Option<(&str, &[String])> = None;
+        let mut matched: Option<(&str, &[String], &Option<String>)> = None;
 
-        for (stored_key, name, roles) in &self.keys {
+        for (stored_key, name, roles, namespace) in &self.keys {
             let stored_bytes = stored_key.as_bytes();
 
             // Only compare if lengths match (length itself is not secret
             // since an attacker can enumerate valid key lengths from the
             // config format, but the content must remain hidden)
             if stored_bytes.len() == input_bytes.len() && stored_bytes.ct_eq(input_bytes).into() {
-                matched = Some((name.as_str(), roles.as_slice()));
+                matched = Some((name.as_str(), roles.as_slice(), namespace));
             }
         }
 
         // Always iterate all keys before returning to avoid early-exit timing
-        matched.map(|(name, roles)| {
+        matched.map(|(name, roles, namespace)| {
             let prefix = if api_key.len() > 13 {
                 format!("{}...", &api_key[..13])
             } else {
@@ -65,6 +78,7 @@ impl PermissionChecker {
                 name: name.to_string(),
                 roles: roles.to_vec(),
                 key_prefix: prefix,
+                namespace: namespace.clone(),
             }
         })
     }
@@ -101,6 +115,19 @@ impl PermissionChecker {
                 }
             }
         }
+
+        // Isolation mode: an api key's namespace implicitly grants read+search
+        // on `<namespace>*` (never write/delete/admin) without an explicit role.
+        if self.isolation
+            && matches!(permission, Permission::Read | Permission::Search)
+        {
+            if let Some(ns) = &user.namespace {
+                if collection.starts_with(ns.as_str()) {
+                    return true;
+                }
+            }
+        }
+
         false
     }
 }
@@ -120,7 +147,7 @@ fn glob_match(pattern: &str, value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{RoleConfig, SecurityConfig};
+    use crate::config::{ApiKeyConfig, RoleConfig, SecurityConfig};
 
     fn checker_with_role(role: &str, pattern: &str, perms: &[&str]) -> PermissionChecker {
         let mut roles = HashMap::new();
@@ -138,6 +165,7 @@ mod tests {
             api_keys: vec![],
             roles,
             audit: Default::default(),
+            isolation: false,
         };
         PermissionChecker::new(&config)
     }
@@ -147,7 +175,24 @@ mod tests {
             name: "u".into(),
             roles: roles.iter().map(|r| r.to_string()).collect(),
             key_prefix: String::new(),
+            namespace: None,
         }
+    }
+
+    fn checker_with_namespace_key(namespace: &str, isolation: bool) -> PermissionChecker {
+        let config = SecurityConfig {
+            enabled: true,
+            api_keys: vec![ApiKeyConfig {
+                key: "k".into(),
+                name: "mikalv".into(),
+                roles: vec![],
+                namespace: Some(namespace.to_string()),
+            }],
+            roles: HashMap::new(),
+            audit: Default::default(),
+            isolation,
+        };
+        PermissionChecker::new(&config)
     }
 
     #[test]
@@ -167,5 +212,27 @@ mod tests {
             visible,
             vec!["ws_mikalv_code_a".to_string(), "ws_mikalv_docs_b".to_string()]
         );
+    }
+
+    #[test]
+    fn isolation_namespace_grants_read_and_search_without_explicit_role() {
+        let checker = checker_with_namespace_key("ws_mikalv_", true);
+        let user = checker.authenticate("k").unwrap();
+
+        // Namespace implicitly grants search+read within it...
+        assert!(checker.check_permission(&user, "ws_mikalv_code_a", Permission::Search));
+        assert!(checker.check_permission(&user, "ws_mikalv_code_a", Permission::Read));
+        // ...but nothing outside it, and not write/delete/admin inside it.
+        assert!(!checker.check_permission(&user, "ws_eyrmedical_b", Permission::Search));
+        assert!(!checker.check_permission(&user, "ws_mikalv_code_a", Permission::Write));
+    }
+
+    #[test]
+    fn namespace_does_not_grant_when_isolation_off() {
+        let checker = checker_with_namespace_key("ws_mikalv_", false);
+        let user = checker.authenticate("k").unwrap();
+
+        // With isolation disabled the namespace is inert (default-deny).
+        assert!(!checker.check_permission(&user, "ws_mikalv_code_a", Permission::Search));
     }
 }

--- a/prism/src/security/permissions.rs
+++ b/prism/src/security/permissions.rs
@@ -125,9 +125,7 @@ impl PermissionChecker {
 
         // Isolation mode: an api key's namespace implicitly grants read+search
         // on `<namespace>*` (never write/delete/admin) without an explicit role.
-        if self.isolation
-            && matches!(permission, Permission::Read | Permission::Search)
-        {
+        if self.isolation && matches!(permission, Permission::Read | Permission::Search) {
             if let Some(ns) = &user.namespace {
                 if collection.starts_with(ns.as_str()) {
                     return true;
@@ -217,7 +215,10 @@ mod tests {
 
         assert_eq!(
             visible,
-            vec!["ws_mikalv_code_a".to_string(), "ws_mikalv_docs_b".to_string()]
+            vec![
+                "ws_mikalv_code_a".to_string(),
+                "ws_mikalv_docs_b".to_string()
+            ]
         );
     }
 

--- a/prism/src/security/permissions.rs
+++ b/prism/src/security/permissions.rs
@@ -69,6 +69,21 @@ impl PermissionChecker {
         })
     }
 
+    /// Return the subset of `all` collections the user may act on with the given
+    /// permission. This is the single resolver used by every enumeration and
+    /// fan-out surface (collection listing, multi-search, ES-compat `_cat`, etc.)
+    /// so isolation is enforced consistently and no surface is missed.
+    pub fn visible_collections(
+        &self,
+        user: &AuthUser,
+        all: Vec<String>,
+        permission: Permission,
+    ) -> Vec<String> {
+        all.into_iter()
+            .filter(|c| self.check_permission(user, c, permission))
+            .collect()
+    }
+
     pub fn check_permission(
         &self,
         user: &AuthUser,
@@ -99,5 +114,58 @@ fn glob_match(pattern: &str, value: &str) -> bool {
         value.starts_with(prefix)
     } else {
         pattern == value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{RoleConfig, SecurityConfig};
+
+    fn checker_with_role(role: &str, pattern: &str, perms: &[&str]) -> PermissionChecker {
+        let mut roles = HashMap::new();
+        roles.insert(
+            role.to_string(),
+            RoleConfig {
+                collections: HashMap::from([(
+                    pattern.to_string(),
+                    perms.iter().map(|p| p.to_string()).collect(),
+                )]),
+            },
+        );
+        let config = SecurityConfig {
+            enabled: true,
+            api_keys: vec![],
+            roles,
+            audit: Default::default(),
+        };
+        PermissionChecker::new(&config)
+    }
+
+    fn user_with_roles(roles: &[&str]) -> AuthUser {
+        AuthUser {
+            name: "u".into(),
+            roles: roles.iter().map(|r| r.to_string()).collect(),
+            key_prefix: String::new(),
+        }
+    }
+
+    #[test]
+    fn visible_collections_returns_only_permitted() {
+        let checker = checker_with_role("mikalv", "ws_mikalv_*", &["search"]);
+        let user = user_with_roles(&["mikalv"]);
+        let all = vec![
+            "ws_mikalv_code_a".to_string(),
+            "ws_mikalv_docs_b".to_string(),
+            "ws_eyrmedical_code_c".to_string(),
+            "mail".to_string(),
+        ];
+
+        let visible = checker.visible_collections(&user, all, Permission::Search);
+
+        assert_eq!(
+            visible,
+            vec!["ws_mikalv_code_a".to_string(), "ws_mikalv_docs_b".to_string()]
+        );
     }
 }

--- a/prism/src/security/permissions.rs
+++ b/prism/src/security/permissions.rs
@@ -98,6 +98,13 @@ impl PermissionChecker {
             .collect()
     }
 
+    /// Whether opt-in isolation mode is enabled. Surfaces use this to decide
+    /// whether a denied single-collection access should 404 (hide existence)
+    /// rather than 403.
+    pub fn is_isolation(&self) -> bool {
+        self.isolation
+    }
+
     pub fn check_permission(
         &self,
         user: &AuthUser,

--- a/prism/src/security/types.rs
+++ b/prism/src/security/types.rs
@@ -3,6 +3,8 @@ pub struct AuthUser {
     pub name: String,
     pub roles: Vec<String>,
     pub key_prefix: String,
+    /// Collection namespace from the api key (used by isolation mode).
+    pub namespace: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/prism/tests/e2e_api_test.rs
+++ b/prism/tests/e2e_api_test.rs
@@ -144,7 +144,11 @@ async fn test_root_endpoint() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(body["name"], "prism");
@@ -171,7 +175,11 @@ async fn test_create_collection_and_list() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     let collections = body["collections"].as_array().unwrap();
@@ -217,7 +225,11 @@ async fn test_index_and_search() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     let results = body["results"].as_array().unwrap();
@@ -264,7 +276,11 @@ async fn test_index_and_get_by_id() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(body["id"], "doc-1");
@@ -304,7 +320,11 @@ async fn test_collection_stats() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(body["collection"], "test-e2e");
@@ -333,7 +353,11 @@ async fn test_collection_schema_endpoint() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(body["collection"], "test-e2e");
@@ -380,7 +404,11 @@ async fn test_search_empty_collection() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     let results = body["results"].as_array().unwrap();
@@ -463,7 +491,11 @@ async fn test_index_with_all_field_types() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(body["id"], "all-fields-doc");
@@ -842,7 +874,11 @@ async fn test_get_top_terms() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(body["field"], "title");
@@ -898,7 +934,11 @@ async fn test_get_segments() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     // Should have segment information
@@ -965,7 +1005,11 @@ async fn test_suggest_endpoint() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     assert!(body["suggestions"].is_array());
@@ -1038,7 +1082,11 @@ async fn test_more_like_this_by_text() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     assert!(body["results"].is_array());
@@ -1152,7 +1200,11 @@ async fn test_multi_search_endpoint() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     assert!(body["results"].is_array());
@@ -1184,7 +1236,11 @@ async fn test_multi_index_search_comma_separated() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     assert!(body["results"].is_array());
@@ -1252,7 +1308,11 @@ async fn test_search_with_highlight() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     let results = body["results"].as_array().unwrap();
@@ -1296,7 +1356,11 @@ async fn test_search_with_min_score() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     let results = body["results"].as_array().unwrap();
@@ -1354,7 +1418,11 @@ async fn test_server_info_endpoint() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     assert!(body["version"].is_string());
@@ -1470,7 +1538,11 @@ async fn test_list_pipelines_endpoint() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     assert!(body["pipelines"].is_array());
@@ -1503,7 +1575,11 @@ async fn test_simple_search_api() {
     let status = resp.status().as_u16();
     let bytes = resp.bytes().await.unwrap();
     if status != 200 {
-        panic!("Status was {}, body: {}", status, String::from_utf8_lossy(&bytes));
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
     }
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     assert!(body["results"].is_array());

--- a/prism/tests/security_integration_test.rs
+++ b/prism/tests/security_integration_test.rs
@@ -61,11 +61,13 @@ fn security_config() -> SecurityConfig {
                 key: "test_admin_key".to_string(),
                 name: "admin".to_string(),
                 roles: vec!["admin".to_string()],
+                namespace: None,
             },
             ApiKeyConfig {
                 key: "test_reader_key".to_string(),
                 name: "reader".to_string(),
                 roles: vec!["reader".to_string()],
+                namespace: None,
             },
         ],
         roles,
@@ -73,6 +75,7 @@ fn security_config() -> SecurityConfig {
             enabled: false,
             index_to_collection: false,
         },
+        isolation: false,
     }
 }
 

--- a/prism/tests/security_test.rs
+++ b/prism/tests/security_test.rs
@@ -47,20 +47,24 @@ fn test_config() -> SecurityConfig {
                 key: "prism_ak_admin".to_string(),
                 name: "admin".to_string(),
                 roles: vec!["admin".to_string()],
+                namespace: None,
             },
             ApiKeyConfig {
                 key: "prism_ak_analyst".to_string(),
                 name: "analyst".to_string(),
                 roles: vec!["analyst".to_string()],
+                namespace: None,
             },
             ApiKeyConfig {
                 key: "prism_ak_writer".to_string(),
                 name: "writer".to_string(),
                 roles: vec!["writer".to_string()],
+                namespace: None,
             },
         ],
         roles,
         audit: Default::default(),
+        isolation: false,
     }
 }
 

--- a/prism/tests/user_isolation_test.rs
+++ b/prism/tests/user_isolation_test.rs
@@ -57,6 +57,7 @@ fn checker_granting(role: &str, pattern: &str, perms: &[&str]) -> Arc<Permission
         api_keys: vec![],
         roles,
         audit: Default::default(),
+        isolation: false,
     }))
 }
 
@@ -65,6 +66,7 @@ fn user_with_role(role: &str) -> AuthUser {
         name: role.to_string(),
         roles: vec![role.to_string()],
         key_prefix: String::new(),
+        namespace: None,
     }
 }
 

--- a/prism/tests/user_isolation_test.rs
+++ b/prism/tests/user_isolation_test.rs
@@ -1,0 +1,99 @@
+//! Integration tests for user-isolation collection visibility.
+//!
+//! An authenticated identity must only see the collections it has been granted
+//! access to. Here we call the `/admin/collections` handler directly with an
+//! auth context and assert it filters via the permission model.
+
+use axum::extract::State;
+use axum::Extension;
+use prism::api::routes::list_collections;
+use prism::backends::{TextBackend, VectorBackend};
+use prism::collection::CollectionManager;
+use prism::config::{RoleConfig, SecurityConfig};
+use prism::schema::CollectionSchema;
+use prism::security::permissions::PermissionChecker;
+use prism::security::types::AuthUser;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+fn text_schema_yaml(name: &str) -> String {
+    format!(
+        "collection: {name}\nbackends:\n  text:\n    fields:\n      - name: title\n        type: text\n        indexed: true\n"
+    )
+}
+
+async fn manager_with(names: &[&str]) -> (TempDir, Arc<CollectionManager>) {
+    let temp = TempDir::new().unwrap();
+    let schemas_dir = temp.path().join("schemas");
+    let data_dir = temp.path().join("data");
+    std::fs::create_dir_all(&schemas_dir).unwrap();
+    let text = Arc::new(TextBackend::new(&data_dir).unwrap());
+    let vector = Arc::new(VectorBackend::new(&data_dir).unwrap());
+    let manager =
+        Arc::new(CollectionManager::new(&schemas_dir, text, vector, None).unwrap());
+    manager.initialize().await.unwrap();
+    for name in names {
+        let schema: CollectionSchema =
+            serde_yaml::from_str(&text_schema_yaml(name)).unwrap();
+        manager.add_collection(schema).await.unwrap();
+    }
+    (temp, manager)
+}
+
+fn checker_granting(role: &str, pattern: &str, perms: &[&str]) -> Arc<PermissionChecker> {
+    let mut roles = HashMap::new();
+    roles.insert(
+        role.to_string(),
+        RoleConfig {
+            collections: HashMap::from([(
+                pattern.to_string(),
+                perms.iter().map(|p| p.to_string()).collect(),
+            )]),
+        },
+    );
+    Arc::new(PermissionChecker::new(&SecurityConfig {
+        enabled: true,
+        api_keys: vec![],
+        roles,
+        audit: Default::default(),
+    }))
+}
+
+fn user_with_role(role: &str) -> AuthUser {
+    AuthUser {
+        name: role.to_string(),
+        roles: vec![role.to_string()],
+        key_prefix: String::new(),
+    }
+}
+
+#[tokio::test]
+async fn list_collections_filters_to_visible_when_authenticated() {
+    let (_temp, manager) = manager_with(&["ws_mikalv_a", "ws_eyrmedical_b"]).await;
+    let checker = checker_granting("mikalv", "ws_mikalv_*", &["search"]);
+    let user = user_with_role("mikalv");
+
+    let resp = list_collections(
+        State(manager.clone()),
+        Some(Extension(user)),
+        Some(Extension(checker)),
+    )
+    .await;
+
+    assert_eq!(resp.0.collections, vec!["ws_mikalv_a".to_string()]);
+}
+
+#[tokio::test]
+async fn list_collections_returns_all_when_unauthenticated() {
+    let (_temp, manager) = manager_with(&["ws_mikalv_a", "ws_eyrmedical_b"]).await;
+
+    let resp = list_collections(State(manager.clone()), None, None).await;
+
+    let mut got = resp.0.collections.clone();
+    got.sort();
+    assert_eq!(
+        got,
+        vec!["ws_eyrmedical_b".to_string(), "ws_mikalv_a".to_string()]
+    );
+}

--- a/prism/tests/user_isolation_test.rs
+++ b/prism/tests/user_isolation_test.rs
@@ -4,9 +4,10 @@
 //! access to. Here we call the `/admin/collections` handler directly with an
 //! auth context and assert it filters via the permission model.
 
-use axum::extract::State;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
 use axum::Extension;
-use prism::api::routes::list_collections;
+use prism::api::routes::{list_collections, search, SearchRequest};
 use prism::backends::{TextBackend, VectorBackend};
 use prism::collection::CollectionManager;
 use prism::config::{RoleConfig, SecurityConfig};
@@ -84,6 +85,27 @@ async fn list_collections_filters_to_visible_when_authenticated() {
     .await;
 
     assert_eq!(resp.0.collections, vec!["ws_mikalv_a".to_string()]);
+}
+
+#[tokio::test]
+async fn per_collection_search_denied_for_unauthorized_collection() {
+    let (_temp, manager) = manager_with(&["ws_mikalv_a", "ws_eyrmedical_b"]).await;
+    let checker = checker_granting("mikalv", "ws_mikalv_*", &["search"]);
+    let user = user_with_role("mikalv");
+    let req: SearchRequest = serde_json::from_value(serde_json::json!({"query": "*"})).unwrap();
+
+    // Directly searching a collection outside the caller's grant is forbidden,
+    // even though simple_search already filters — this closes the direct-name hole.
+    let res = search(
+        Path("ws_eyrmedical_b".to_string()),
+        State(manager.clone()),
+        Some(Extension(user)),
+        Some(Extension(checker)),
+        axum::Json(req),
+    )
+    .await;
+
+    assert!(matches!(res, Err((StatusCode::FORBIDDEN, _))));
 }
 
 #[tokio::test]

--- a/prism/tests/user_isolation_test.rs
+++ b/prism/tests/user_isolation_test.rs
@@ -33,12 +33,10 @@ async fn manager_with(names: &[&str]) -> (TempDir, Arc<CollectionManager>) {
     std::fs::create_dir_all(&schemas_dir).unwrap();
     let text = Arc::new(TextBackend::new(&data_dir).unwrap());
     let vector = Arc::new(VectorBackend::new(&data_dir).unwrap());
-    let manager =
-        Arc::new(CollectionManager::new(&schemas_dir, text, vector, None).unwrap());
+    let manager = Arc::new(CollectionManager::new(&schemas_dir, text, vector, None).unwrap());
     manager.initialize().await.unwrap();
     for name in names {
-        let schema: CollectionSchema =
-            serde_yaml::from_str(&text_schema_yaml(name)).unwrap();
+        let schema: CollectionSchema = serde_yaml::from_str(&text_schema_yaml(name)).unwrap();
         manager.add_collection(schema).await.unwrap();
     }
     (temp, manager)

--- a/prism/tests/user_isolation_test.rs
+++ b/prism/tests/user_isolation_test.rs
@@ -7,7 +7,9 @@
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::Extension;
-use prism::api::routes::{list_collections, search, SearchRequest};
+use prism::api::routes::{
+    get_collection_stats, get_document, list_collections, search, SearchRequest,
+};
 use prism::backends::{TextBackend, VectorBackend};
 use prism::collection::CollectionManager;
 use prism::config::{RoleConfig, SecurityConfig};
@@ -106,6 +108,50 @@ async fn per_collection_search_denied_for_unauthorized_collection() {
     .await;
 
     assert!(matches!(res, Err((StatusCode::FORBIDDEN, _))));
+}
+
+#[tokio::test]
+async fn per_collection_get_document_denied_for_unauthorized_collection() {
+    let (_temp, manager) = manager_with(&["ws_mikalv_a", "ws_eyrmedical_b"]).await;
+    let checker = checker_granting("mikalv", "ws_mikalv_*", &["read"]);
+    let user = user_with_role("mikalv");
+
+    let res = get_document(
+        Path(("ws_eyrmedical_b".to_string(), "doc1".to_string())),
+        State(manager.clone()),
+        Some(Extension(user)),
+        Some(Extension(checker)),
+    )
+    .await;
+
+    assert!(matches!(res, Err(StatusCode::FORBIDDEN)));
+}
+
+#[tokio::test]
+async fn per_collection_stats_denied_for_unauthorized_collection() {
+    let (_temp, manager) = manager_with(&["ws_mikalv_a", "ws_eyrmedical_b"]).await;
+    let checker = checker_granting("mikalv", "ws_mikalv_*", &["read"]);
+    let user = user_with_role("mikalv");
+
+    // Own collection is allowed...
+    let ok = get_collection_stats(
+        Path("ws_mikalv_a".to_string()),
+        State(manager.clone()),
+        Some(Extension(user.clone())),
+        Some(Extension(checker.clone())),
+    )
+    .await;
+    assert!(ok.is_ok());
+
+    // ...another user's is not.
+    let denied = get_collection_stats(
+        Path("ws_eyrmedical_b".to_string()),
+        State(manager.clone()),
+        Some(Extension(user)),
+        Some(Extension(checker)),
+    )
+    .await;
+    assert!(matches!(denied, Err(StatusCode::FORBIDDEN)));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Implements the core of user isolation (#86): an opt-in mode where an authenticated identity sees/acts on **only its own collections**. Off by default; single-tenant behavior unchanged. Three TDD-driven parts:

## 1. Enumeration filter
- `PermissionChecker::visible_collections()` — the single resolver every fan-out surface reuses.
- `GET /admin/collections` filters through it (was leaking every name).

## 2. Isolation mode + per-key namespace
- `[security] isolation` flag + `ApiKeyConfig.namespace`. Under isolation, a key's namespace implicitly grants **read+search on `<namespace>*`** (never write/delete/admin) — no hand-written role per user. `AuthUser` carries it; `check_permission` honors it only when isolation is on.

## 3. Single-collection read-route audit
Every per-collection read/search route now authorizes via a shared `authorize_collection()` helper (Read for reads, Search for search-like): `/collections/:c/search`, `get_document`, `list_documents`, `stats`, `schema` (+raw), `aggregate`, `_suggest`, `_mlt`, `segments`. Denied access → **404 under isolation** (hide existence), else 403. Closes the direct-name `/search` ACL bypass.

## Config
```toml
[security]
enabled = true
isolation = true
[[security.api_keys]]
key = "..."
name = "mikalv"
namespace = "ws_mikalv_"   # sees only ws_mikalv_*
```

## Tests (TDD red→green)
7 new isolation tests + lib unit tests. No regressions: lib `security::` 22, `security_test` 5, `security_integration` 6, `user_isolation` 5, `e2e_api` 38 (no-auth path unchanged). CHANGELOG updated.

## Follow-up (separate, tracked in #86)
ES-compat surface (`_cat/indices`, cross-index `_search`); cluster/federated propagation; UI consumes the filtered list.

Design: `docs/plans/2026-08-03-user-isolation-design.md`. Closes the core of #86.