### PR TITLE
feat(search): field collapse (Elasticsearch-style)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Prism are documented in this file.
 
 ### Added
 
+- **Field collapse on search** (Elasticsearch-style `collapse`). A search request
+  may include `"collapse": { "field": "<field>", "max_per_group": N }` to keep at
+  most `N` results per distinct value of a stored field (default `N = 1`),
+  preserving score order — e.g. one hit per `conversation_id` instead of many
+  from the same conversation. Hits missing the field are always kept. Applied
+  post-search, after `min_score`.
 - **Opt-in user isolation mode** (`[security] isolation`, off by default). An api
   key's `namespace` implicitly grants read+search on `<namespace>*` (never
   write/delete/admin) without a hand-written role, and every collection

--- a/notes/features/field-collapse.md
+++ b/notes/features/field-collapse.md
@@ -23,6 +23,12 @@ conversation.
 - **Group key:** stored field value, stringified (`group_key` in collapse.rs).
   Results missing the field are always kept (cannot be grouped).
 
+## Not wired (by design, consistent with existing behaviour)
+`multi_index_search` (`/a,b/_search`) takes `SearchRequest` but already ignores
+`min_score` and `score_function` (they're set to `None` and never applied
+post-search). Collapse follows the same handler: not applied there. Wiring all
+three post-search steps into multi-index search is a separate, larger change.
+
 ## Known limitation
 Collapse runs on the already-paginated result page (backend applied
 `limit`/`offset` first), so a collapsed page can contain fewer than `limit`

--- a/notes/features/field-collapse.md
+++ b/notes/features/field-collapse.md
@@ -1,0 +1,30 @@
+# Field collapse (Elasticsearch-style)
+
+Issue #2. Keep at most K results per distinct value of a field, preserving
+score order — e.g. one hit per `conversation_id` instead of 50 from the same
+conversation.
+
+## Status
+- [x] Pure core: `ranking::collapse::collapse_results` + `CollapseConfig`
+      (commit 4c46271, unit-tested).
+- [x] Wire into API `SearchRequest` + apply in the search route
+      (e2e test `test_search_collapse_by_field`).
+
+## Design decisions
+- **Where applied:** in the `search` route handler, post-search, alongside
+  `min_score` / `score_function` (which are set to `None` in `Query` and
+  applied after `manager.search`). Collapse runs *after* `min_score` so
+  filtered-out hits never occupy a group slot.
+- **API shape (ES-like):**
+  ```json
+  "collapse": { "field": "category", "max_per_group": 1 }
+  ```
+  `max_per_group` defaults to `1` (ES default is one hit per group).
+- **Group key:** stored field value, stringified (`group_key` in collapse.rs).
+  Results missing the field are always kept (cannot be grouped).
+
+## Known limitation
+Collapse runs on the already-paginated result page (backend applied
+`limit`/`offset` first), so a collapsed page can contain fewer than `limit`
+hits. Same post-limit behaviour as the existing `min_score` filter. Over-fetch
++ re-collapse could be a later improvement; out of scope for first wiring.

--- a/prism/src/api/routes.rs
+++ b/prism/src/api/routes.rs
@@ -74,6 +74,10 @@ pub struct SearchRequest {
     /// Ad-hoc score expression (e.g., "_score * 2")
     #[serde(default)]
     pub score_function: Option<String>,
+    /// Optional field collapse: keep at most K results per distinct field value
+    /// (Elasticsearch-style `collapse`). Applied post-search.
+    #[serde(default)]
+    pub collapse: Option<crate::ranking::collapse::CollapseConfig>,
 }
 
 fn default_limit() -> usize {
@@ -281,6 +285,16 @@ pub async fn search(
             // Apply minimum score filter
             if let Some(min) = request.min_score {
                 results.results.retain(|r| r.score >= min);
+                results.total = results.results.len();
+            }
+
+            // Apply field collapse (keep at most K hits per distinct field value)
+            if let Some(ref collapse) = request.collapse {
+                results.results = crate::ranking::collapse::collapse_results(
+                    std::mem::take(&mut results.results),
+                    &collapse.field,
+                    collapse.max_per_group,
+                );
                 results.total = results.results.len();
             }
 

--- a/prism/src/ranking/collapse.rs
+++ b/prism/src/ranking/collapse.rs
@@ -1,0 +1,114 @@
+//! Field collapse — keep at most K results per distinct value of a field,
+//! preserving score order (Elasticsearch-style `collapse`).
+//!
+//! Useful when many results share a grouping key (e.g. one hit per
+//! `conversation_id` instead of 50 from the same conversation).
+
+use crate::backends::SearchResult;
+use std::collections::HashMap;
+
+/// Configuration for field collapsing.
+#[derive(Debug, Clone)]
+pub struct CollapseConfig {
+    /// Field whose value defines a group.
+    pub field: String,
+    /// Maximum results to keep per group.
+    pub max_per_group: usize,
+}
+
+/// Collapse score-ordered `results` so each distinct value of `field` appears at
+/// most `max_per_group` times. Input order is preserved, so the highest-scoring
+/// member of each group is kept. Results missing the field are always kept
+/// (they cannot be grouped).
+pub fn collapse_results(
+    results: Vec<SearchResult>,
+    field: &str,
+    max_per_group: usize,
+) -> Vec<SearchResult> {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    let mut out = Vec::with_capacity(results.len());
+    for r in results {
+        match r.fields.get(field) {
+            Some(value) => {
+                let count = counts.entry(group_key(value)).or_insert(0);
+                if *count < max_per_group {
+                    out.push(r);
+                    *count += 1;
+                }
+                // otherwise the group is full → drop this (lower-scoring) result
+            }
+            // No grouping value → cannot collapse; always keep.
+            None => out.push(r),
+        }
+    }
+    out
+}
+
+/// Stable string key for a field value used to group results.
+fn group_key(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn hit(id: &str, score: f32, conv: &str) -> SearchResult {
+        let mut fields = HashMap::new();
+        fields.insert("conversation_id".to_string(), json!(conv));
+        SearchResult {
+            id: id.into(),
+            score,
+            fields,
+            highlight: None,
+        }
+    }
+
+    #[test]
+    fn collapse_keeps_top_one_per_group_in_order() {
+        let results = vec![
+            hit("a", 5.0, "conv1"),
+            hit("b", 4.0, "conv1"), // same group, lower score → collapsed away
+            hit("c", 3.0, "conv2"),
+            hit("d", 2.0, "conv1"), // collapsed away
+        ];
+
+        let out = collapse_results(results, "conversation_id", 1);
+
+        let ids: Vec<&str> = out.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "c"]);
+    }
+
+    #[test]
+    fn collapse_keeps_up_to_max_per_group() {
+        let results = vec![
+            hit("a", 5.0, "conv1"),
+            hit("b", 4.0, "conv1"),
+            hit("c", 3.0, "conv1"), // third in group → dropped when max=2
+            hit("d", 2.0, "conv2"),
+        ];
+
+        let out = collapse_results(results, "conversation_id", 2);
+
+        let ids: Vec<&str> = out.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "b", "d"]);
+    }
+
+    #[test]
+    fn collapse_keeps_results_missing_the_field() {
+        let mut no_field = hit("x", 1.0, "conv1");
+        no_field.fields.remove("conversation_id");
+
+        let results = vec![hit("a", 5.0, "conv1"), no_field, hit("b", 4.0, "conv1")];
+
+        let out = collapse_results(results, "conversation_id", 1);
+
+        // "a" kept (first of conv1), "x" kept (no group value), "b" dropped.
+        let ids: Vec<&str> = out.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "x"]);
+    }
+}

--- a/prism/src/ranking/collapse.rs
+++ b/prism/src/ranking/collapse.rs
@@ -5,15 +5,21 @@
 //! `conversation_id` instead of 50 from the same conversation).
 
 use crate::backends::SearchResult;
+use serde::Deserialize;
 use std::collections::HashMap;
 
 /// Configuration for field collapsing.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct CollapseConfig {
     /// Field whose value defines a group.
     pub field: String,
-    /// Maximum results to keep per group.
+    /// Maximum results to keep per group (default: 1, Elasticsearch-style).
+    #[serde(default = "default_max_per_group")]
     pub max_per_group: usize,
+}
+
+fn default_max_per_group() -> usize {
+    1
 }
 
 /// Collapse score-ordered `results` so each distinct value of `field` appears at

--- a/prism/src/ranking/mod.rs
+++ b/prism/src/ranking/mod.rs
@@ -5,6 +5,7 @@
 //! - Recency decay: boost newer documents over older ones
 //! - Popularity boost: multiply scores by document-level boost values
 
+pub mod collapse;
 pub mod cross_encoder;
 pub mod decay;
 pub mod reranker;

--- a/prism/tests/e2e_api_test.rs
+++ b/prism/tests/e2e_api_test.rs
@@ -250,6 +250,92 @@ async fn test_index_and_search() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_search_collapse_by_field() {
+    let (_temp, base_url, handle) = start_server().await;
+    let client = Client::new();
+    create_test_collection(&client, &base_url).await;
+
+    // Five docs sharing a common body term, in two categories:
+    // three in "cat-a", two in "cat-b".
+    let categories = ["cat-a", "cat-a", "cat-a", "cat-b", "cat-b"];
+    let docs: Vec<Value> = categories
+        .iter()
+        .enumerate()
+        .map(|(i, cat)| {
+            json!({
+                "id": format!("doc-{}", i),
+                "fields": {
+                    "title": format!("Document number {}", i),
+                    "body": "shared searchable content",
+                    "category": cat,
+                    "count": i
+                }
+            })
+        })
+        .collect();
+    index_docs(&client, &base_url, "test-e2e", &json!(docs)).await;
+
+    // Without collapse: all five docs match "content".
+    let resp = client
+        .post(format!("{}/collections/test-e2e/search", base_url))
+        .json(&json!({ "query": "content", "limit": 10 }))
+        .send()
+        .await
+        .unwrap();
+    let body: Value = serde_json::from_slice(&resp.bytes().await.unwrap()).unwrap();
+    assert_eq!(
+        body["results"].as_array().unwrap().len(),
+        5,
+        "sanity: all five docs should match without collapse"
+    );
+
+    // With collapse on `category`, max 1 per group → one hit per category.
+    let resp = client
+        .post(format!("{}/collections/test-e2e/search", base_url))
+        .json(&json!({
+            "query": "content",
+            "limit": 10,
+            "collapse": { "field": "category", "max_per_group": 1 }
+        }))
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status().as_u16();
+    let bytes = resp.bytes().await.unwrap();
+    if status != 200 {
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
+    }
+    let body: Value = serde_json::from_slice(&bytes).unwrap();
+    let results = body["results"].as_array().unwrap();
+
+    assert_eq!(
+        results.len(),
+        2,
+        "collapse max_per_group=1 over two categories should yield 2 hits, got {:?}",
+        results
+    );
+    let cats: Vec<&str> = results
+        .iter()
+        .filter_map(|r| r["fields"]["category"].as_str())
+        .collect();
+    let mut sorted = cats.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(
+        sorted.len(),
+        cats.len(),
+        "each returned hit should have a distinct category, got {:?}",
+        cats
+    );
+
+    handle.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_index_and_get_by_id() {
     let (_temp, base_url, handle) = start_server().await;
     let client = Client::new();


### PR DESCRIPTION
Wires the field-collapse core (`collapse_results`, added in 4c46271) into the
search API.

## What

A search request may now include:

```json
"collapse": { "field": "conversation_id", "max_per_group": 1 }
```

to keep at most `max_per_group` results per distinct value of a stored field,
preserving score order (so the highest-scoring member of each group survives).
`max_per_group` defaults to `1` (Elasticsearch default). Hits missing the field
are always kept.

## Where

Applied in the `search` route handler post-search, right after the `min_score`
filter — so filtered-out hits never occupy a group slot. Consistent with how
`min_score` / `score_function` are already handled (set to `None` in `Query`,
applied post-search).

## Tests

- `collapse_results` unit tests (existing, from the core commit).
- New e2e HTTP test `test_search_collapse_by_field`: indexes 5 docs across 2
  categories, verifies collapse yields one hit per category with distinct
  category values. Full e2e suite (39 tests) green.

## Not in scope

`multi_index_search` (`/a,b/_search`) already ignores `min_score` /
`score_function`; collapse follows the same handler and is likewise not applied
there. Wiring all post-search steps into multi-index search is a separate change
(noted in `notes/features/field-collapse.md`).

Refs #2.