### PR TITLE
feat(search): semantic near-duplicate collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Prism are documented in this file.
 
 ### Added
 
+- **Semantic near-duplicate collapse on search.** A search request may include
+  `"near_dup": { "threshold": 0.95 }` to drop results whose embedding cosine
+  similarity to a higher-scoring result is at/above `threshold` (default 0.95),
+  preserving score order — so a page isn't dominated by many rephrasings of the
+  same content. Comparison vectors are fetched from the collection's vector
+  backend for the returned hits (new `SearchBackend::get_vectors`); hits without
+  a vector are always kept. Requires a collection with a vector backend; applied
+  post-search, after field `collapse`.
 - **Field collapse on search** (Elasticsearch-style `collapse`). A search request
   may include `"collapse": { "field": "<field>", "max_per_group": N }` to keep at
   most `N` results per distinct value of a stored field (default `N = 1`),

--- a/notes/features/near-dup-collapse.md
+++ b/notes/features/near-dup-collapse.md
@@ -1,0 +1,36 @@
+# Semantic near-duplicate collapse
+
+Issue #3. Drop results whose embedding is too similar to a higher-scoring
+result already kept (greedy diversification), so a page isn't dominated by many
+rephrasings of the same content. Sibling of exact field collapse (#2).
+
+## Status
+- [x] Pure core: `ranking::near_dup::collapse_near_duplicates` (greedy cosine
+      dedup over an `id -> vector` map) + `NearDupConfig`. Unit-tested.
+- [x] Vector plumbing: `SearchBackend::get_vectors` (default empty),
+      `VectorBackend`/`HybridBackend` impls, `CollectionManager::vectors_for`.
+      Integration-tested (`test_get_vectors_returns_stored_embeddings`).
+- [x] API wiring: `near_dup` on `SearchRequest`, applied in the search route
+      after field collapse. E2e-tested (`test_search_near_duplicate_collapse`).
+
+## Design decisions
+- **Vector source (chosen):** fetched from the vector backend for the returned
+  result ids, not carried on `SearchResult`. `SearchResult` gains no serialized
+  field; the route builds an `id -> vector` map via `manager.vectors_for` and
+  passes it to the pure core. `get_vector` reads the stored HNSW point in the
+  segment (`HnswBackend::get_point`).
+- **API shape:** `"near_dup": { "threshold": 0.95 }`. `threshold` = cosine
+  similarity at/above which two hits are duplicates (default 0.95).
+- **Order:** greedy over score-ordered results; the highest-scoring member of
+  each near-duplicate cluster survives. Compared against *all* kept vectors, not
+  just the previous one.
+- **Missing vectors:** hits with no vector in the map are always kept (cannot be
+  compared) — e.g. text-only hits in a hybrid result, or a collection with no
+  vector backend (`vectors_for` returns empty → no-op).
+
+## Known limitations
+- Runs on the already-paginated page (post-`limit`), like `min_score` /
+  `collapse`, so a collapsed page may contain fewer than `limit` hits.
+- Only the `/collections/:c/search` route is wired (not `multi_index_search`),
+  matching the field-collapse decision.
+- Greedy O(kept²) cosine over the page; fine for page-sized result sets.

--- a/prism/src/api/routes.rs
+++ b/prism/src/api/routes.rs
@@ -78,6 +78,11 @@ pub struct SearchRequest {
     /// (Elasticsearch-style `collapse`). Applied post-search.
     #[serde(default)]
     pub collapse: Option<crate::ranking::collapse::CollapseConfig>,
+    /// Optional semantic near-duplicate collapse: drop results whose embedding
+    /// is too similar to a higher-scoring result. Applied post-search, after
+    /// `collapse`. Requires a collection with a vector backend.
+    #[serde(default)]
+    pub near_dup: Option<crate::ranking::near_dup::NearDupConfig>,
 }
 
 fn default_limit() -> usize {
@@ -294,6 +299,20 @@ pub async fn search(
                     std::mem::take(&mut results.results),
                     &collapse.field,
                     collapse.max_per_group,
+                );
+                results.total = results.results.len();
+            }
+
+            // Apply semantic near-duplicate collapse (drop hits too similar to a
+            // higher-scoring one). Vectors are fetched from the collection's
+            // vector backend for the surviving result ids.
+            if let Some(ref near_dup) = request.near_dup {
+                let ids: Vec<String> = results.results.iter().map(|r| r.id.clone()).collect();
+                let vectors = manager.vectors_for(&collection, &ids).await;
+                results.results = crate::ranking::near_dup::collapse_near_duplicates(
+                    std::mem::take(&mut results.results),
+                    &vectors,
+                    near_dup.threshold,
                 );
                 results.total = results.results.len();
             }

--- a/prism/src/backends/hybrid.rs
+++ b/prism/src/backends/hybrid.rs
@@ -413,6 +413,15 @@ impl SearchBackend for HybridSearchCoordinator {
         Ok(())
     }
 
+    async fn get_vectors(
+        &self,
+        collection: &str,
+        ids: &[String],
+    ) -> Result<std::collections::HashMap<String, Vec<f32>>> {
+        // Embeddings live in the vector backend.
+        self.vector_backend.get_vectors(collection, ids).await
+    }
+
     async fn stats(&self, collection: &str) -> Result<BackendStats> {
         // Combine stats conservatively (max document_count)
         let t = self.text_backend.stats(collection).await?;

--- a/prism/src/backends/trait.rs
+++ b/prism/src/backends/trait.rs
@@ -130,6 +130,18 @@ pub trait SearchBackend: Send + Sync {
         query: &Query,
         aggregations: Vec<crate::aggregations::AggregationRequest>,
     ) -> Result<SearchResultsWithAggs>;
+
+    /// Fetch stored embedding vectors for the given document ids, when the
+    /// backend has them. Missing ids are simply absent from the map. The default
+    /// returns an empty map (text-only backends store no vectors). Used by
+    /// semantic near-duplicate collapse.
+    async fn get_vectors(
+        &self,
+        _collection: &str,
+        _ids: &[String],
+    ) -> Result<HashMap<String, Vec<f32>>> {
+        Ok(HashMap::new())
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/prism/src/backends/vector/backend.rs
+++ b/prism/src/backends/vector/backend.rs
@@ -741,6 +741,28 @@ impl SearchBackend for VectorBackend {
         }
     }
 
+    async fn get_vectors(
+        &self,
+        collection: &str,
+        ids: &[String],
+    ) -> Result<HashMap<String, Vec<f32>>> {
+        let indexes = self.indexes.read();
+        let sharded = match indexes.get(collection) {
+            Some(s) => s,
+            // Best-effort: no index for this collection → no vectors.
+            None => return Ok(HashMap::new()),
+        };
+
+        let mut out = HashMap::with_capacity(ids.len());
+        for id in ids {
+            let shard_id = shard_for_doc(id, sharded.num_shards) as usize;
+            if let Some(v) = sharded.shards[shard_id].get_vector(id) {
+                out.insert(id.clone(), v);
+            }
+        }
+        Ok(out)
+    }
+
     async fn delete(&self, collection: &str, ids: Vec<String>) -> Result<()> {
         let save_lock_opt = {
             let mut indexes = self.indexes.write();

--- a/prism/src/backends/vector/index.rs
+++ b/prism/src/backends/vector/index.rs
@@ -161,6 +161,14 @@ impl InstantDistanceAdapter {
         }
         map
     }
+
+    /// Return the stored vector for a single key, if present.
+    pub fn get_point(&self, key: u32) -> Option<Vec<f32>> {
+        self.keys
+            .iter()
+            .position(|k| *k == key)
+            .map(|i| self.points[i].v.clone())
+    }
 }
 
 #[cfg(feature = "vector-instant")]

--- a/prism/src/backends/vector/segment.rs
+++ b/prism/src/backends/vector/segment.rs
@@ -161,6 +161,16 @@ impl VectorSegment {
         }
     }
 
+    /// Get the stored embedding vector for a document, if present and not
+    /// tombstoned.
+    pub fn get_vector(&self, doc_id: &str) -> Option<Vec<f32>> {
+        let key = *self.id_to_key.get(doc_id)?;
+        if self.tombstones.contains(key) {
+            return None;
+        }
+        self.hnsw.get_point(key)
+    }
+
     pub fn extract_all(&self) -> Vec<(String, Vec<f32>, HashMap<String, serde_json::Value>)> {
         let points = self.hnsw.extract_all_points();
         let mut out = Vec::new();

--- a/prism/src/backends/vector/shard.rs
+++ b/prism/src/backends/vector/shard.rs
@@ -135,6 +135,19 @@ impl VectorShard {
         None
     }
 
+    /// Get the stored embedding vector for a document from any segment.
+    pub fn get_vector(&self, doc_id: &str) -> Option<Vec<f32>> {
+        if let Some(v) = self.active_segment.get_vector(doc_id) {
+            return Some(v);
+        }
+        for seg in &self.sealed_segments {
+            if let Some(v) = seg.get_vector(doc_id) {
+                return Some(v);
+            }
+        }
+        None
+    }
+
     /// Check if this shard contains the document.
     pub fn contains(&self, doc_id: &str) -> bool {
         if self.active_segment.contains(doc_id) {

--- a/prism/src/collection/manager.rs
+++ b/prism/src/collection/manager.rs
@@ -838,6 +838,22 @@ impl CollectionManager {
         &self.vector_backend
     }
 
+    /// Fetch stored embedding vectors for the given result ids of a collection,
+    /// resolved through the same backend that serves its searches. Best-effort:
+    /// returns an empty map when the collection has no vector-bearing backend.
+    /// Used by semantic near-duplicate collapse.
+    pub async fn vectors_for(
+        &self,
+        collection: &str,
+        ids: &[String],
+    ) -> std::collections::HashMap<String, Vec<f32>> {
+        let backend = self.per_collection_backends.read().get(collection).cloned();
+        match backend {
+            Some(b) => b.get_vectors(collection, ids).await.unwrap_or_default(),
+            None => std::collections::HashMap::new(),
+        }
+    }
+
     /// Get the graph backend for a collection, if one is configured.
     pub fn graph_backend(&self, collection: &str) -> Option<Arc<ShardedGraphBackend>> {
         self.per_collection_graphs.read().get(collection).cloned()

--- a/prism/src/ranking/mod.rs
+++ b/prism/src/ranking/mod.rs
@@ -8,6 +8,7 @@
 pub mod collapse;
 pub mod cross_encoder;
 pub mod decay;
+pub mod near_dup;
 pub mod reranker;
 pub mod score_function;
 

--- a/prism/src/ranking/near_dup.rs
+++ b/prism/src/ranking/near_dup.rs
@@ -9,7 +9,21 @@
 //! `id -> vector` map (fetched from the vector backend for the returned hits).
 
 use crate::backends::SearchResult;
+use serde::Deserialize;
 use std::collections::HashMap;
+
+/// Configuration for semantic near-duplicate collapse.
+#[derive(Debug, Clone, Deserialize)]
+pub struct NearDupConfig {
+    /// Cosine similarity at or above which two hits are treated as duplicates
+    /// (default: 0.95).
+    #[serde(default = "default_threshold")]
+    pub threshold: f32,
+}
+
+fn default_threshold() -> f32 {
+    0.95
+}
 
 /// Collapse score-ordered `results`, dropping any hit whose cosine similarity to
 /// an already-kept hit is `>= threshold`. Input order is preserved, so the

--- a/prism/src/ranking/near_dup.rs
+++ b/prism/src/ranking/near_dup.rs
@@ -4,51 +4,41 @@
 //! Complements exact field collapse (`ranking::collapse`): instead of grouping
 //! on a shared field value, results are grouped by embedding proximity, so a
 //! page won't be dominated by many rephrasings of the same content.
+//!
+//! Result embeddings are not carried on `SearchResult`; the caller supplies an
+//! `id -> vector` map (fetched from the vector backend for the returned hits).
 
 use crate::backends::SearchResult;
+use std::collections::HashMap;
 
 /// Collapse score-ordered `results`, dropping any hit whose cosine similarity to
 /// an already-kept hit is `>= threshold`. Input order is preserved, so the
 /// highest-scoring member of each near-duplicate cluster is the one kept.
 ///
-/// The comparison vector is read from `results[i].fields[vector_field]`, which
-/// must be a JSON array of numbers. Hits without a usable vector are always kept
-/// (they cannot be compared).
+/// The comparison vector for a hit is looked up in `vectors` by result id. Hits
+/// with no vector in the map are always kept (they cannot be compared).
 pub fn collapse_near_duplicates(
     results: Vec<SearchResult>,
-    vector_field: &str,
+    vectors: &HashMap<String, Vec<f32>>,
     threshold: f32,
 ) -> Vec<SearchResult> {
-    let mut kept_vectors: Vec<Vec<f32>> = Vec::new();
+    let mut kept: Vec<&Vec<f32>> = Vec::new();
     let mut out = Vec::with_capacity(results.len());
     for r in results {
-        match extract_vector(&r, vector_field) {
+        match vectors.get(&r.id) {
             Some(v) => {
-                let is_dup = kept_vectors
-                    .iter()
-                    .any(|k| cosine_similarity(&v, k) >= threshold);
+                let is_dup = kept.iter().any(|k| cosine_similarity(v, k) >= threshold);
                 if !is_dup {
-                    kept_vectors.push(v);
+                    kept.push(v);
                     out.push(r);
                 }
                 // otherwise: near-duplicate of a higher-scoring hit → drop
             }
-            // No usable vector → cannot compare; always keep.
+            // No vector available → cannot compare; always keep.
             None => out.push(r),
         }
     }
     out
-}
-
-/// Extract a `Vec<f32>` embedding from a result field, if present and well-formed.
-fn extract_vector(result: &SearchResult, field: &str) -> Option<Vec<f32>> {
-    let arr = result.fields.get(field)?.as_array()?;
-    let v: Vec<f32> = arr.iter().filter_map(|x| x.as_f64().map(|n| n as f32)).collect();
-    if v.len() == arr.len() && !v.is_empty() {
-        Some(v)
-    } else {
-        None
-    }
 }
 
 /// Cosine similarity of two equal-length vectors. Returns 0.0 when the lengths
@@ -70,31 +60,30 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
-    use std::collections::HashMap;
 
-    fn hit(id: &str, score: f32, vector: Option<Vec<f32>>) -> SearchResult {
-        let mut fields = HashMap::new();
-        if let Some(v) = vector {
-            fields.insert("embedding".to_string(), json!(v));
-        }
+    fn hit(id: &str, score: f32) -> SearchResult {
         SearchResult {
             id: id.into(),
             score,
-            fields,
+            fields: HashMap::new(),
             highlight: None,
         }
     }
 
+    fn vecs(pairs: &[(&str, Vec<f32>)]) -> HashMap<String, Vec<f32>> {
+        pairs.iter().map(|(id, v)| (id.to_string(), v.clone())).collect()
+    }
+
     #[test]
     fn drops_near_duplicate_of_higher_scoring_hit() {
-        let results = vec![
-            hit("a", 5.0, Some(vec![1.0, 0.0])),
-            hit("b", 4.0, Some(vec![0.99, 0.01])), // ~identical to a → dropped
-            hit("c", 3.0, Some(vec![0.0, 1.0])),   // orthogonal → kept
-        ];
+        let results = vec![hit("a", 5.0), hit("b", 4.0), hit("c", 3.0)];
+        let vectors = vecs(&[
+            ("a", vec![1.0, 0.0]),
+            ("b", vec![0.99, 0.01]), // ~identical to a → dropped
+            ("c", vec![0.0, 1.0]),   // orthogonal → kept
+        ]);
 
-        let out = collapse_near_duplicates(results, "embedding", 0.9);
+        let out = collapse_near_duplicates(results, &vectors, 0.9);
 
         let ids: Vec<&str> = out.iter().map(|r| r.id.as_str()).collect();
         assert_eq!(ids, vec!["a", "c"]);
@@ -102,12 +91,13 @@ mod tests {
 
     #[test]
     fn keeps_distinct_hits_below_threshold() {
-        let results = vec![
-            hit("a", 5.0, Some(vec![1.0, 0.0])),
-            hit("b", 4.0, Some(vec![0.7, 0.7])), // sim ~0.707 < 0.9 → kept
-        ];
+        let results = vec![hit("a", 5.0), hit("b", 4.0)];
+        let vectors = vecs(&[
+            ("a", vec![1.0, 0.0]),
+            ("b", vec![0.7, 0.7]), // sim ~0.707 < 0.9 → kept
+        ]);
 
-        let out = collapse_near_duplicates(results, "embedding", 0.9);
+        let out = collapse_near_duplicates(results, &vectors, 0.9);
 
         let ids: Vec<&str> = out.iter().map(|r| r.id.as_str()).collect();
         assert_eq!(ids, vec!["a", "b"]);
@@ -115,13 +105,14 @@ mod tests {
 
     #[test]
     fn keeps_hits_without_a_vector() {
-        let results = vec![
-            hit("a", 5.0, Some(vec![1.0, 0.0])),
-            hit("x", 4.0, None), // no embedding → cannot compare → kept
-            hit("b", 3.0, Some(vec![1.0, 0.0])), // duplicate of a → dropped
-        ];
+        let results = vec![hit("a", 5.0), hit("x", 4.0), hit("b", 3.0)];
+        // "x" has no entry in the vectors map → cannot compare → kept.
+        let vectors = vecs(&[
+            ("a", vec![1.0, 0.0]),
+            ("b", vec![1.0, 0.0]), // duplicate of a → dropped
+        ]);
 
-        let out = collapse_near_duplicates(results, "embedding", 0.9);
+        let out = collapse_near_duplicates(results, &vectors, 0.9);
 
         let ids: Vec<&str> = out.iter().map(|r| r.id.as_str()).collect();
         assert_eq!(ids, vec!["a", "x"]);
@@ -132,13 +123,14 @@ mod tests {
         // Kept set becomes [a, d] (orthogonal). `e` is a near-duplicate of `a`
         // but orthogonal to `d` (the most recently kept). It must still drop,
         // proving we compare against every kept hit, not just the previous one.
-        let results = vec![
-            hit("a", 5.0, Some(vec![1.0, 0.0])),
-            hit("d", 4.0, Some(vec![0.0, 1.0])),
-            hit("e", 3.0, Some(vec![0.98, 0.02])), // dup of a, not of d → dropped
-        ];
+        let results = vec![hit("a", 5.0), hit("d", 4.0), hit("e", 3.0)];
+        let vectors = vecs(&[
+            ("a", vec![1.0, 0.0]),
+            ("d", vec![0.0, 1.0]),
+            ("e", vec![0.98, 0.02]), // dup of a, not of d → dropped
+        ]);
 
-        let out = collapse_near_duplicates(results, "embedding", 0.9);
+        let out = collapse_near_duplicates(results, &vectors, 0.9);
 
         let ids: Vec<&str> = out.iter().map(|r| r.id.as_str()).collect();
         assert_eq!(ids, vec!["a", "d"]);

--- a/prism/src/ranking/near_dup.rs
+++ b/prism/src/ranking/near_dup.rs
@@ -85,7 +85,10 @@ mod tests {
     }
 
     fn vecs(pairs: &[(&str, Vec<f32>)]) -> HashMap<String, Vec<f32>> {
-        pairs.iter().map(|(id, v)| (id.to_string(), v.clone())).collect()
+        pairs
+            .iter()
+            .map(|(id, v)| (id.to_string(), v.clone()))
+            .collect()
     }
 
     #[test]

--- a/prism/src/ranking/near_dup.rs
+++ b/prism/src/ranking/near_dup.rs
@@ -1,0 +1,146 @@
+//! Semantic near-duplicate collapse — drop results whose embedding is too
+//! similar to a higher-scoring result already kept (greedy diversification).
+//!
+//! Complements exact field collapse (`ranking::collapse`): instead of grouping
+//! on a shared field value, results are grouped by embedding proximity, so a
+//! page won't be dominated by many rephrasings of the same content.
+
+use crate::backends::SearchResult;
+
+/// Collapse score-ordered `results`, dropping any hit whose cosine similarity to
+/// an already-kept hit is `>= threshold`. Input order is preserved, so the
+/// highest-scoring member of each near-duplicate cluster is the one kept.
+///
+/// The comparison vector is read from `results[i].fields[vector_field]`, which
+/// must be a JSON array of numbers. Hits without a usable vector are always kept
+/// (they cannot be compared).
+pub fn collapse_near_duplicates(
+    results: Vec<SearchResult>,
+    vector_field: &str,
+    threshold: f32,
+) -> Vec<SearchResult> {
+    let mut kept_vectors: Vec<Vec<f32>> = Vec::new();
+    let mut out = Vec::with_capacity(results.len());
+    for r in results {
+        match extract_vector(&r, vector_field) {
+            Some(v) => {
+                let is_dup = kept_vectors
+                    .iter()
+                    .any(|k| cosine_similarity(&v, k) >= threshold);
+                if !is_dup {
+                    kept_vectors.push(v);
+                    out.push(r);
+                }
+                // otherwise: near-duplicate of a higher-scoring hit → drop
+            }
+            // No usable vector → cannot compare; always keep.
+            None => out.push(r),
+        }
+    }
+    out
+}
+
+/// Extract a `Vec<f32>` embedding from a result field, if present and well-formed.
+fn extract_vector(result: &SearchResult, field: &str) -> Option<Vec<f32>> {
+    let arr = result.fields.get(field)?.as_array()?;
+    let v: Vec<f32> = arr.iter().filter_map(|x| x.as_f64().map(|n| n as f32)).collect();
+    if v.len() == arr.len() && !v.is_empty() {
+        Some(v)
+    } else {
+        None
+    }
+}
+
+/// Cosine similarity of two equal-length vectors. Returns 0.0 when the lengths
+/// differ or either vector has zero magnitude (nothing meaningful to compare).
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() {
+        return 0.0;
+    }
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let na = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let nb = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if na == 0.0 || nb == 0.0 {
+        0.0
+    } else {
+        dot / (na * nb)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    fn hit(id: &str, score: f32, vector: Option<Vec<f32>>) -> SearchResult {
+        let mut fields = HashMap::new();
+        if let Some(v) = vector {
+            fields.insert("embedding".to_string(), json!(v));
+        }
+        SearchResult {
+            id: id.into(),
+            score,
+            fields,
+            highlight: None,
+        }
+    }
+
+    #[test]
+    fn drops_near_duplicate_of_higher_scoring_hit() {
+        let results = vec![
+            hit("a", 5.0, Some(vec![1.0, 0.0])),
+            hit("b", 4.0, Some(vec![0.99, 0.01])), // ~identical to a → dropped
+            hit("c", 3.0, Some(vec![0.0, 1.0])),   // orthogonal → kept
+        ];
+
+        let out = collapse_near_duplicates(results, "embedding", 0.9);
+
+        let ids: Vec<&str> = out.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "c"]);
+    }
+
+    #[test]
+    fn keeps_distinct_hits_below_threshold() {
+        let results = vec![
+            hit("a", 5.0, Some(vec![1.0, 0.0])),
+            hit("b", 4.0, Some(vec![0.7, 0.7])), // sim ~0.707 < 0.9 → kept
+        ];
+
+        let out = collapse_near_duplicates(results, "embedding", 0.9);
+
+        let ids: Vec<&str> = out.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn keeps_hits_without_a_vector() {
+        let results = vec![
+            hit("a", 5.0, Some(vec![1.0, 0.0])),
+            hit("x", 4.0, None), // no embedding → cannot compare → kept
+            hit("b", 3.0, Some(vec![1.0, 0.0])), // duplicate of a → dropped
+        ];
+
+        let out = collapse_near_duplicates(results, "embedding", 0.9);
+
+        let ids: Vec<&str> = out.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "x"]);
+    }
+
+    #[test]
+    fn compares_against_all_kept_not_just_the_last() {
+        // Kept set becomes [a, d] (orthogonal). `e` is a near-duplicate of `a`
+        // but orthogonal to `d` (the most recently kept). It must still drop,
+        // proving we compare against every kept hit, not just the previous one.
+        let results = vec![
+            hit("a", 5.0, Some(vec![1.0, 0.0])),
+            hit("d", 4.0, Some(vec![0.0, 1.0])),
+            hit("e", 3.0, Some(vec![0.98, 0.02])), // dup of a, not of d → dropped
+        ];
+
+        let out = collapse_near_duplicates(results, "embedding", 0.9);
+
+        let ids: Vec<&str> = out.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "d"]);
+    }
+}

--- a/prism/tests/e2e_api_test.rs
+++ b/prism/tests/e2e_api_test.rs
@@ -435,8 +435,16 @@ async fn test_search_near_duplicate_collapse() {
     // One survivor from {a,b}, one from {c,d}.
     let cluster1 = ids.iter().filter(|id| **id == "a" || **id == "b").count();
     let cluster2 = ids.iter().filter(|id| **id == "c" || **id == "d").count();
-    assert_eq!(cluster1, 1, "exactly one of a/b should survive, got {:?}", ids);
-    assert_eq!(cluster2, 1, "exactly one of c/d should survive, got {:?}", ids);
+    assert_eq!(
+        cluster1, 1,
+        "exactly one of a/b should survive, got {:?}",
+        ids
+    );
+    assert_eq!(
+        cluster2, 1,
+        "exactly one of c/d should survive, got {:?}",
+        ids
+    );
 
     handle.abort();
 }

--- a/prism/tests/e2e_api_test.rs
+++ b/prism/tests/e2e_api_test.rs
@@ -336,6 +336,112 @@ async fn test_search_collapse_by_field() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_search_near_duplicate_collapse() {
+    let (_temp, base_url, handle) = start_server().await;
+    let client = Client::new();
+
+    // A hybrid (text + vector) collection with 4-dim embeddings. Hybrid is used
+    // because the /search route feeds the query vector via `query.vector`, which
+    // the hybrid coordinator honours (the raw vector backend expects it inline).
+    let resp = client
+        .put(format!("{}/collections/vec-e2e", base_url))
+        .json(&json!({
+            "collection": "vec-e2e",
+            "backends": {
+                "text": {
+                    "fields": [
+                        {"name": "body", "type": "text", "stored": true, "indexed": true}
+                    ]
+                },
+                "vector": { "embedding_field": "embedding", "dimension": 4 }
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        matches!(resp.status().as_u16(), 200 | 201),
+        "creating hybrid collection failed: {}",
+        resp.status()
+    );
+
+    // Two near-duplicate clusters: {a,b} ~ [1,0,0,0] and {c,d} ~ [0,1,0,0].
+    // All share a text term so a hybrid query returns every doc.
+    let docs = json!([
+        { "id": "a", "fields": { "body": "shared content", "embedding": [1.0, 0.0, 0.0, 0.0] } },
+        { "id": "b", "fields": { "body": "shared content", "embedding": [0.999, 0.001, 0.0, 0.0] } },
+        { "id": "c", "fields": { "body": "shared content", "embedding": [0.0, 1.0, 0.0, 0.0] } },
+        { "id": "d", "fields": { "body": "shared content", "embedding": [0.001, 0.999, 0.0, 0.0] } },
+    ]);
+    index_docs(&client, &base_url, "vec-e2e", &docs).await;
+
+    // Sanity: a hybrid query returns all four without near-dup collapse.
+    let resp = client
+        .post(format!("{}/collections/vec-e2e/search", base_url))
+        .json(&json!({ "query": "content", "vector": [1.0, 1.0, 0.0, 0.0], "limit": 10 }))
+        .send()
+        .await
+        .unwrap();
+    let sanity_status = resp.status().as_u16();
+    let sanity_bytes = resp.bytes().await.unwrap();
+    assert_eq!(
+        sanity_status,
+        200,
+        "sanity search failed: {}",
+        String::from_utf8_lossy(&sanity_bytes)
+    );
+    let body: Value = serde_json::from_slice(&sanity_bytes).unwrap();
+    assert_eq!(
+        body["results"].as_array().unwrap().len(),
+        4,
+        "sanity: all four docs should be returned without near-dup collapse"
+    );
+
+    // With near-dup collapse, each cluster reduces to one hit → two results.
+    let resp = client
+        .post(format!("{}/collections/vec-e2e/search", base_url))
+        .json(&json!({
+            "query": "content",
+            "vector": [1.0, 1.0, 0.0, 0.0],
+            "limit": 10,
+            "near_dup": { "threshold": 0.95 }
+        }))
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status().as_u16();
+    let bytes = resp.bytes().await.unwrap();
+    if status != 200 {
+        panic!(
+            "Status was {}, body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
+    }
+    let body: Value = serde_json::from_slice(&bytes).unwrap();
+    let ids: Vec<&str> = body["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|r| r["id"].as_str())
+        .collect();
+
+    assert_eq!(
+        ids.len(),
+        2,
+        "near-dup collapse should keep one hit per cluster, got {:?}",
+        ids
+    );
+    // One survivor from {a,b}, one from {c,d}.
+    let cluster1 = ids.iter().filter(|id| **id == "a" || **id == "b").count();
+    let cluster2 = ids.iter().filter(|id| **id == "c" || **id == "d").count();
+    assert_eq!(cluster1, 1, "exactly one of a/b should survive, got {:?}", ids);
+    assert_eq!(cluster2, 1, "exactly one of c/d should survive, got {:?}", ids);
+
+    handle.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_index_and_get_by_id() {
     let (_temp, base_url, handle) = start_server().await;
     let client = Client::new();

--- a/prism/tests/vector_backend_test.rs
+++ b/prism/tests/vector_backend_test.rs
@@ -146,6 +146,72 @@ async fn test_index_and_search() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_get_vectors_returns_stored_embeddings() {
+    use prism::backends::SearchBackend;
+    use std::collections::HashMap;
+
+    let temp_dir = TempDir::new().unwrap();
+    let backend = VectorBackend::new(temp_dir.path()).unwrap();
+
+    let schema = CollectionSchema {
+        collection: "gv".to_string(),
+        description: None,
+        backends: Backends {
+            text: None,
+            vector: Some(VectorBackendConfig {
+                wal: prism::schema::types::WalConfig::default(),
+                embedding_field: "embedding".to_string(),
+                dimension: 4,
+                distance: VectorDistance::Cosine,
+                hnsw_m: 16,
+                hnsw_ef_construction: 200,
+                hnsw_ef_search: 100,
+                vector_weight: 0.5,
+                num_shards: 1,
+                shard_oversample: 2.5,
+                compaction: Default::default(),
+            }),
+            graph: None,
+        },
+        indexing: Default::default(),
+        quota: Default::default(),
+        embedding_generation: None,
+        facets: None,
+        boosting: None,
+        storage: Default::default(),
+        system_fields: Default::default(),
+        hybrid: None,
+        replication: None,
+        reranking: None,
+        ilm_policy: None,
+    };
+    backend.initialize("gv", &schema).await.unwrap();
+
+    let docs: Vec<Document> = [("d1", [1.0, 0.0, 0.0, 0.0]), ("d2", [0.0, 1.0, 0.0, 0.0])]
+        .into_iter()
+        .map(|(id, v)| {
+            let mut f = HashMap::new();
+            f.insert("embedding".to_string(), serde_json::json!(v));
+            Document {
+                id: id.to_string(),
+                fields: f,
+            }
+        })
+        .collect();
+    SearchBackend::index(&backend, "gv", docs).await.unwrap();
+
+    let ids = vec!["d1".to_string(), "d2".to_string(), "missing".to_string()];
+    let vectors = SearchBackend::get_vectors(&backend, "gv", &ids)
+        .await
+        .unwrap();
+
+    assert_eq!(vectors.len(), 2, "only stored ids should be returned");
+    assert_eq!(vectors.get("d1").unwrap(), &vec![1.0, 0.0, 0.0, 0.0]);
+    assert_eq!(vectors.get("d2").unwrap(), &vec![0.0, 1.0, 0.0, 0.0]);
+    assert!(vectors.get("missing").is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_search_offset_paginates() {
     use prism::backends::SearchBackend;
     use std::collections::HashMap;

--- a/prism/tests/vector_backend_test.rs
+++ b/prism/tests/vector_backend_test.rs
@@ -208,7 +208,7 @@ async fn test_get_vectors_returns_stored_embeddings() {
     assert_eq!(vectors.len(), 2, "only stored ids should be returned");
     assert_eq!(vectors.get("d1").unwrap(), &vec![1.0, 0.0, 0.0, 0.0]);
     assert_eq!(vectors.get("d2").unwrap(), &vec![0.0, 1.0, 0.0, 0.0]);
-    assert!(vectors.get("missing").is_none());
+    assert!(!vectors.contains_key("missing"));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
Adds semantic near-duplicate collapse of search results — the sibling of field
collapse (#88). **Stacked on `feat/field-collapse` (#88); review/merge that
first.** Base will be retargeted to `main` once #88 lands.

## What

A search request may include:

```json
"near_dup": { "threshold": 0.95 }
```

to drop any hit whose embedding cosine-similarity to a higher-scoring, already-
kept hit is `>= threshold` (default `0.95`), preserving score order — so a page
isn't dominated by many rephrasings of the same content.

## How (per the chosen design)

Result embeddings aren't carried on `SearchResult`, so vectors are **fetched
from the vector backend** for the returned hits:

- New `SearchBackend::get_vectors(collection, ids) -> id→vector` (default empty
  for text-only backends). `VectorBackend` resolves each id to its shard and
  reads the stored HNSW point (`segment/shard::get_vector`,
  `HnswBackend::get_point`); `HybridBackend` delegates to its vector backend.
- `CollectionManager::vectors_for` resolves the collection's search backend and
  calls it.
- The pure core `ranking::near_dup::collapse_near_duplicates(results, &vectors,
  threshold)` does greedy cosine dedup against **all** kept vectors. Hits with no
  vector (text-only hits in a hybrid page, or no vector backend) are always kept.

Applied in the `search` route after field `collapse`.

## Tests (TDD)

- `ranking::near_dup` unit tests: dedup, threshold boundary, missing-vector
  passthrough, compare-against-all-kept.
- `test_get_vectors_returns_stored_embeddings`: vector backend returns stored
  embeddings by id.
- `test_search_near_duplicate_collapse`: e2e hybrid collection with two
  near-duplicate clusters collapses to one hit per cluster.

Full e2e suite (40) + ranking lib tests green; clippy clean.

## Not in scope

Only `/collections/:c/search` is wired (not `multi_index_search`), matching #88.
Runs on the already-paginated page (post-`limit`), like `min_score`/`collapse`.
See `notes/features/near-dup-collapse.md`.

Refs #3.