### PR TITLE
feat(agentimport): add opencode source adapter

### DIFF
--- a/clients/python/agentimport/README.md
+++ b/clients/python/agentimport/README.md
@@ -17,6 +17,7 @@ Import AI assistant conversations into [Prism](https://github.com/mikalv/prism) 
 | Kilo Code | `kilo` | Cline-family task JSON | `…/globalStorage/kilocode.kilo-code/tasks/` |
 | Cline | `cline` | Cline-family task JSON | `…/globalStorage/saoudrizwan.claude-dev/tasks/` |
 | Roo Code | `roo` | Cline-family task JSON | `…/globalStorage/rooveterinaryinc.roo-cline/tasks/` |
+| opencode | `opencode` | SQLite `opencode.db` or `storage/` JSON | `~/.local/share/opencode/` |
 
 The `Name(s)` column is what you pass to `--sources` (e.g. `--sources pi,cursor,kilo`).
 

--- a/clients/python/agentimport/src/agentimport/cli.py
+++ b/clients/python/agentimport/src/agentimport/cli.py
@@ -37,7 +37,7 @@ def main(ctx: click.Context, prism_url: str, api_key: str | None, state_db: str 
 
 
 @main.command()
-@click.option("--sources", default=None, help="Comma-separated sources (claude_code,codex,gemini,copilot,chatgpt,antigravity,pi,cursor,kilo,cline,roo)")
+@click.option("--sources", default=None, help="Comma-separated sources (claude_code,codex,gemini,copilot,chatgpt,antigravity,pi,cursor,kilo,cline,roo,opencode)")
 @click.option("--include-tool-results", is_flag=True, help="Include tool result content")
 @click.option("--include-thinking", is_flag=True, help="Include thinking/reasoning blocks")
 @click.option("--roles", default=None, help="Comma-separated roles to include (user,assistant,system,tool)")

--- a/clients/python/agentimport/src/agentimport/config.py
+++ b/clients/python/agentimport/src/agentimport/config.py
@@ -50,6 +50,7 @@ class Config:
             "copilot": SourceConfig(roots=[home / ".copilot"]),
             "chatgpt_export": SourceConfig(enabled=False, roots=[]),
             "antigravity": SourceConfig(roots=[home / ".gemini" / "antigravity" / "brain"]),
+            "opencode": SourceConfig(roots=[home / ".local" / "share" / "opencode"]),
         }
 
     def get_enabled_sources(self) -> list[str]:

--- a/clients/python/agentimport/src/agentimport/sources/base.py
+++ b/clients/python/agentimport/src/agentimport/sources/base.py
@@ -46,6 +46,7 @@ def get_all_sources() -> list[Source]:
     from agentimport.sources.copilot import CopilotSource
     from agentimport.sources.cursor import CursorSource
     from agentimport.sources.gemini import GeminiSource
+    from agentimport.sources.opencode import OpencodeSource
     from agentimport.sources.pi import PiSource
 
     return [
@@ -60,6 +61,7 @@ def get_all_sources() -> list[Source]:
         KiloSource(),
         ClineSource(),
         RooSource(),
+        OpencodeSource(),
     ]
 
 

--- a/clients/python/agentimport/src/agentimport/sources/opencode.py
+++ b/clients/python/agentimport/src/agentimport/sources/opencode.py
@@ -1,0 +1,225 @@
+"""opencode adapter — parses opencode sessions from SQLite or file storage.
+
+opencode (https://opencode.ai) stores conversations under
+``~/.local/share/opencode``. Two on-disk layouts exist:
+
+* **SQLite** (`opencode.db`): tables ``session``, ``message`` and ``part``, each
+  ``part``/``message`` carrying a JSON ``data`` blob. Newer/forked builds keep
+  message text here.
+* **File storage** (`storage/`): ``storage/message/<ses>/<msg>.json`` for message
+  metadata and ``storage/part/<ses>/<msg>/<prt>.json`` for the content parts.
+
+The adapter reads whichever is present, preferring the DB when both exist (so a
+session isn't imported twice). Parts share one normalization path regardless of
+source: ``text`` → message, ``reasoning`` → thinking, ``tool`` → tool_call.
+Synthetic hook parts and non-content parts (``step-*``, ``snapshot`` …) are
+skipped.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Iterator
+
+from agentimport.models import NormalizedMessage
+
+logger = logging.getLogger(__name__)
+
+
+class OpencodeSource:
+    """Parse opencode conversations from an SQLite DB or file storage."""
+
+    @property
+    def name(self) -> str:
+        return "opencode"
+
+    def default_roots(self) -> list[Path]:
+        return [Path.home() / ".local" / "share" / "opencode"]
+
+    def discover(self, roots: list[Path]) -> Iterable[Path]:
+        for root in roots:
+            if not root.exists():
+                continue
+            db = root / "opencode.db"
+            if db.exists() and _db_has_tables(db):
+                # DB is the source of truth; skip file storage to avoid dupes.
+                yield db
+                continue
+            message_dir = root / "storage" / "message"
+            if message_dir.is_dir():
+                yield from sorted(p for p in message_dir.iterdir() if p.is_dir())
+
+    def parse(self, path: Path) -> Iterator[NormalizedMessage]:
+        if path.is_file() and path.suffix == ".db":
+            yield from self._parse_db(path)
+        elif path.is_dir():
+            yield from self._parse_session_dir(path)
+
+    # -- SQLite -------------------------------------------------------------- #
+
+    def _parse_db(self, db: Path) -> Iterator[NormalizedMessage]:
+        try:
+            conn = sqlite3.connect(f"file:{db}?mode=ro&immutable=1", uri=True)
+        except sqlite3.Error as e:
+            logger.warning("Cannot open opencode DB %s: %s", db, e)
+            return
+        try:
+            sessions = {
+                row[0]: {"title": row[1], "directory": row[2], "model": row[3]}
+                for row in conn.execute(
+                    "SELECT id, title, directory, model, time_created "
+                    "FROM session ORDER BY time_created"
+                )
+            }
+            # Sessions with no metadata row still get parsed (keyed by message).
+            session_ids = list(sessions.keys()) or [
+                row[0] for row in conn.execute("SELECT DISTINCT session_id FROM message")
+            ]
+            for sid in session_ids:
+                meta = sessions.get(sid, {})
+                rows = conn.execute(
+                    "SELECT m.data, p.id, p.data FROM message m "
+                    "JOIN part p ON p.message_id = m.id "
+                    "WHERE m.session_id = ? ORDER BY m.id, p.id",
+                    (sid,),
+                )
+                yield from self._emit(
+                    conv_id=sid,
+                    rows=((json.loads(md), pid, json.loads(pd)) for md, pid, pd in rows),
+                    session_meta=meta,
+                    source_path=f"{db}#session:{sid}",
+                )
+        finally:
+            conn.close()
+
+    # -- File storage -------------------------------------------------------- #
+
+    def _parse_session_dir(self, session_dir: Path) -> Iterator[NormalizedMessage]:
+        sid = session_dir.name
+        storage = session_dir.parent.parent  # storage/
+        part_root = storage / "part" / sid
+        meta = _read_session_info(storage, sid)
+
+        def rows():
+            for msg_file in sorted(session_dir.glob("*.json")):
+                try:
+                    mdata = json.loads(msg_file.read_text(encoding="utf-8", errors="replace"))
+                except (json.JSONDecodeError, OSError) as e:
+                    logger.warning("Failed to read %s: %s", msg_file, e)
+                    continue
+                msg_parts = part_root / msg_file.stem
+                if not msg_parts.is_dir():
+                    continue
+                for part_file in sorted(msg_parts.glob("*.json")):
+                    try:
+                        pdata = json.loads(part_file.read_text(encoding="utf-8", errors="replace"))
+                    except (json.JSONDecodeError, OSError):
+                        continue
+                    yield mdata, part_file.stem, pdata
+
+        yield from self._emit(
+            conv_id=sid,
+            rows=rows(),
+            session_meta=meta,
+            source_path=str(session_dir),
+        )
+
+    # -- Shared normalization ------------------------------------------------ #
+
+    def _emit(
+        self,
+        conv_id: str,
+        rows: Iterable[tuple[dict, str, dict]],
+        session_meta: dict,
+        source_path: str,
+    ) -> Iterator[NormalizedMessage]:
+        seq = 0
+        for mdata, part_id, pdata in rows:
+            content = _part_content(pdata)
+            if content is None:
+                continue
+            content_type, text, tool_name = content
+
+            role = mdata.get("role", "unknown")
+            ts = _parse_epoch_ms((mdata.get("time") or {}).get("created"))
+            model = (
+                mdata.get("modelID")
+                or (mdata.get("model") or {}).get("modelID")
+                or session_meta.get("model")
+            )
+            project = (mdata.get("path") or {}).get("cwd") or session_meta.get("directory")
+
+            yield NormalizedMessage(
+                conversation_id=conv_id,
+                native_msg_id=part_id,
+                source="opencode",
+                role=role,
+                content_type=content_type,
+                text=text,
+                tool_name=tool_name,
+                ts=ts,
+                seq=seq,
+                project=project,
+                model=model,
+                source_path=source_path,
+            )
+            seq += 1
+
+
+def _part_content(part: dict) -> tuple[str, str, str | None] | None:
+    """Map an opencode part to (content_type, text, tool_name), or None to skip."""
+    ptype = part.get("type")
+    if ptype == "text":
+        if part.get("synthetic"):  # hook-injected noise, not real conversation
+            return None
+        text = (part.get("text") or "").strip()
+        return ("message", text, None) if text else None
+    if ptype == "reasoning":
+        text = (part.get("text") or "").strip()
+        return ("thinking", text, None) if text else None
+    if ptype == "tool":
+        tool = part.get("tool")
+        state = part.get("state") or {}
+        text = f"Tool: {tool}\nInput: {json.dumps(state.get('input', {}), default=str)}"
+        return ("tool_call", text, tool)
+    return None
+
+
+def _read_session_info(storage: Path, sid: str) -> dict:
+    """Read optional session metadata from file storage (title/directory)."""
+    for candidate in (storage / "session" / f"{sid}.json", storage / "session" / "info" / f"{sid}.json"):
+        if candidate.is_file():
+            try:
+                data = json.loads(candidate.read_text(encoding="utf-8", errors="replace"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            return {"title": data.get("title"), "directory": data.get("directory"),
+                    "model": data.get("model")}
+    return {}
+
+
+def _db_has_tables(db: Path) -> bool:
+    try:
+        conn = sqlite3.connect(f"file:{db}?mode=ro&immutable=1", uri=True)
+        try:
+            rows = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('message','part')"
+            ).fetchall()
+            return len(rows) == 2
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return False
+
+
+def _parse_epoch_ms(raw: object) -> datetime | None:
+    if not isinstance(raw, (int, float)):
+        return None
+    try:
+        return datetime.fromtimestamp(raw / 1000, tz=timezone.utc)
+    except (ValueError, OSError):
+        return None

--- a/clients/python/agentimport/tests/test_opencode.py
+++ b/clients/python/agentimport/tests/test_opencode.py
@@ -1,0 +1,160 @@
+"""Tests for the opencode source adapter (SQLite DB + file-storage fallback)."""
+
+import json
+import sqlite3
+from pathlib import Path
+
+from agentimport.sources.base import get_source_by_name
+from agentimport.sources.opencode import OpencodeSource
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+def _make_db(path: Path, sessions, messages, parts) -> None:
+    """Build a minimal opencode.db with the columns the adapter reads."""
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE session (
+            id TEXT PRIMARY KEY, title TEXT, directory TEXT,
+            model TEXT, time_created INTEGER
+        );
+        CREATE TABLE message (
+            id TEXT PRIMARY KEY, session_id TEXT, data TEXT
+        );
+        CREATE TABLE part (
+            id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, data TEXT
+        );
+        """
+    )
+    conn.executemany("INSERT INTO session VALUES (?,?,?,?,?)", sessions)
+    conn.executemany("INSERT INTO message VALUES (?,?,?)", messages)
+    conn.executemany("INSERT INTO part VALUES (?,?,?,?)", parts)
+    conn.commit()
+    conn.close()
+
+
+def _sample_db(path: Path) -> None:
+    sessions = [("ses_1", "My chat", "/home/u/proj", "gpt-x", 1_700_000_000_000)]
+    messages = [
+        ("msg_1", "ses_1", json.dumps({"role": "user", "time": {"created": 1_700_000_000_000},
+                                       "model": {"modelID": "gpt-x"}})),
+        ("msg_2", "ses_1", json.dumps({"role": "assistant", "time": {"created": 1_700_000_001_000},
+                                       "modelID": "gpt-x", "path": {"cwd": "/home/u/proj"}})),
+    ]
+    parts = [
+        ("prt_1", "msg_1", "ses_1", json.dumps({"type": "text", "text": "Hello there"})),
+        # synthetic hook noise → skipped
+        ("prt_2", "msg_1", "ses_1", json.dumps({"type": "text", "text": "hook", "synthetic": True})),
+        ("prt_3", "msg_2", "ses_1", json.dumps({"type": "reasoning", "text": "thinking..."})),
+        ("prt_4", "msg_2", "ses_1", json.dumps({"type": "text", "text": "Here is the answer"})),
+        ("prt_5", "msg_2", "ses_1", json.dumps({"type": "tool", "tool": "bash",
+                                                "state": {"input": {"cmd": "ls"}}})),
+        # non-content part → skipped
+        ("prt_6", "msg_2", "ses_1", json.dumps({"type": "step-finish"})),
+    ]
+    _make_db(path, sessions, messages, parts)
+
+
+def _write_file_storage(root: Path) -> None:
+    """Upstream file layout: storage/message/<ses>/<msg>.json + storage/part/<ses>/<msg>/<prt>.json."""
+    msg_dir = root / "storage" / "message" / "ses_1"
+    msg_dir.mkdir(parents=True)
+    (msg_dir / "msg_1.json").write_text(json.dumps(
+        {"role": "user", "time": {"created": 1_700_000_000_000}, "path": {"cwd": "/home/u/proj"}}))
+    (msg_dir / "msg_2.json").write_text(json.dumps(
+        {"role": "assistant", "time": {"created": 1_700_000_001_000}, "modelID": "gpt-x"}))
+
+    p1 = root / "storage" / "part" / "ses_1" / "msg_1"
+    p1.mkdir(parents=True)
+    (p1 / "prt_1.json").write_text(json.dumps({"type": "text", "text": "Hello there"}))
+    p2 = root / "storage" / "part" / "ses_1" / "msg_2"
+    p2.mkdir(parents=True)
+    (p2 / "prt_1.json").write_text(json.dumps({"type": "text", "text": "Here is the answer"}))
+
+
+# --------------------------------------------------------------------------- #
+# Registration
+# --------------------------------------------------------------------------- #
+
+def test_registered_by_name():
+    assert get_source_by_name("opencode") is not None
+    assert OpencodeSource().name == "opencode"
+
+
+# --------------------------------------------------------------------------- #
+# Discover
+# --------------------------------------------------------------------------- #
+
+class TestDiscover:
+    def test_yields_db_when_present(self, tmp_path):
+        _sample_db(tmp_path / "opencode.db")
+        found = list(OpencodeSource().discover([tmp_path]))
+        assert found == [tmp_path / "opencode.db"]
+
+    def test_prefers_db_over_files(self, tmp_path):
+        _sample_db(tmp_path / "opencode.db")
+        _write_file_storage(tmp_path)
+        found = list(OpencodeSource().discover([tmp_path]))
+        # DB present → only the DB is imported (avoids double-import).
+        assert found == [tmp_path / "opencode.db"]
+
+    def test_yields_session_dirs_when_only_files(self, tmp_path):
+        _write_file_storage(tmp_path)
+        found = list(OpencodeSource().discover([tmp_path]))
+        assert found == [tmp_path / "storage" / "message" / "ses_1"]
+
+    def test_skips_missing_root(self, tmp_path):
+        assert list(OpencodeSource().discover([tmp_path / "nope"])) == []
+
+
+# --------------------------------------------------------------------------- #
+# Parse — DB
+# --------------------------------------------------------------------------- #
+
+class TestParseDB:
+    def test_parses_messages_and_parts(self, tmp_path):
+        db = tmp_path / "opencode.db"
+        _sample_db(db)
+        msgs = list(OpencodeSource().parse(db))
+
+        # prt_1 (user text), prt_3 (thinking), prt_4 (assistant text), prt_5 (tool).
+        # Synthetic prt_2 and step-finish prt_6 are dropped.
+        assert [m.text for m in msgs] == [
+            "Hello there",
+            "thinking...",
+            "Here is the answer",
+            "Tool: bash\nInput: {\"cmd\": \"ls\"}",
+        ]
+        assert [m.content_type for m in msgs] == ["message", "thinking", "message", "tool_call"]
+        assert [m.role for m in msgs] == ["user", "assistant", "assistant", "assistant"]
+        assert all(m.source == "opencode" for m in msgs)
+        assert all(m.conversation_id == "ses_1" for m in msgs)
+        assert all(m.project == "/home/u/proj" for m in msgs)
+        assert [m.seq for m in msgs] == [0, 1, 2, 3]
+        assert msgs[3].tool_name == "bash"
+        assert msgs[0].native_msg_id == "prt_1"
+
+    def test_empty_db_yields_nothing(self, tmp_path):
+        db = tmp_path / "opencode.db"
+        _make_db(db, [], [], [])
+        assert list(OpencodeSource().parse(db)) == []
+
+
+# --------------------------------------------------------------------------- #
+# Parse — files
+# --------------------------------------------------------------------------- #
+
+class TestParseFiles:
+    def test_parses_session_dir(self, tmp_path):
+        _write_file_storage(tmp_path)
+        session_dir = tmp_path / "storage" / "message" / "ses_1"
+        msgs = list(OpencodeSource().parse(session_dir))
+
+        assert [m.text for m in msgs] == ["Hello there", "Here is the answer"]
+        assert [m.role for m in msgs] == ["user", "assistant"]
+        assert all(m.conversation_id == "ses_1" for m in msgs)
+        assert all(m.source == "opencode" for m in msgs)
+        assert [m.seq for m in msgs] == [0, 1]

--- a/notes/features/agentimport-opencode.md
+++ b/notes/features/agentimport-opencode.md
@@ -1,0 +1,32 @@
+# agentimport: opencode source adapter
+
+Add an `opencode` source to the agentimport client so opencode
+(https://opencode.ai) conversations are imported into Prism.
+
+## Status
+- [x] `OpencodeSource` (DB + file storage), registered in get_all_sources,
+      config default, CLI help, README. Tested (`tests/test_opencode.py`).
+      Smoke-tested against the real `~/.local/share/opencode/opencode.db`.
+
+## Storage formats (both handled)
+opencode stores under `~/.local/share/opencode`:
+- **SQLite `opencode.db`**: `session(id,title,directory,model,time_created,…)`,
+  `message(id,session_id,data)`, `part(id,message_id,session_id,data)`. `data`
+  is a JSON blob. Forked/newer builds keep message text here (this machine).
+- **File `storage/`**: `storage/message/<ses>/<msg>.json` (metadata) +
+  `storage/part/<ses>/<msg>/<prt>.json` (content). Upstream default.
+
+`discover` prefers the DB when both exist (skips file storage) so a session
+isn't imported twice.
+
+## Part → NormalizedMessage
+Shared `_part_content` for both layouts:
+- `text` → `message` (skip `synthetic:true` hook noise)
+- `reasoning` → `thinking`
+- `tool` → `tool_call` (`tool_name` + JSON input, like the codex adapter)
+- everything else (`step-*`, `snapshot`, …) → skipped
+
+Per-message: role from `data.role`; ts from `data.time.created` (epoch ms);
+model from `data.modelID` or nested `data.model.modelID` or session `model`;
+project from `data.path.cwd` or session `directory`. `native_msg_id` = part id
+(stable dedup key). seq increments per session.


### PR DESCRIPTION
Adds an `opencode` source to the agentimport client, importing
[opencode](https://opencode.ai) conversations into Prism. Independent of the
collapse PRs (#88/#89) — touches only `clients/python/agentimport/`.

## Storage (both layouts handled)

opencode stores under `~/.local/share/opencode`:

- **SQLite `opencode.db`** — `session`/`message`/`part` tables, each with a JSON
  `data` blob. Forked/newer builds keep message text here.
- **File `storage/`** — `storage/message/<ses>/<msg>.json` (metadata) +
  `storage/part/<ses>/<msg>/<prt>.json` (content). Upstream default.

`discover` prefers the DB when both are present (skips file storage) so a
session isn't imported twice; otherwise it yields the per-session message dirs.
Both layouts share one part-normalization path.

## Part → message mapping

- `text` → `message` (synthetic hook parts skipped)
- `reasoning` → `thinking`
- `tool` → `tool_call` (tool name + JSON input, matching the codex adapter)
- `step-*` / `snapshot` / … → skipped

Per message: role, ts (`time.created` epoch-ms), model (`modelID` /
`model.modelID` / session model), project (`path.cwd` / session directory).
`native_msg_id` = part id for stable dedup.

## Tests

`tests/test_opencode.py`: registration, discover (DB present, DB-preferred over
files, files-only, missing root), DB parse (text/reasoning/tool, synthetic +
non-content skipped, seq/roles/model/project), file parse. Full suite: 41
passed, 3 pre-existing skips; ruff clean. Also smoke-tested against the real
`~/.local/share/opencode/opencode.db`.

Registered in `get_all_sources`, default config, `--sources` help, and the
README source table. See `notes/features/agentimport-opencode.md`.

Refs #4.